### PR TITLE
Add Do extension method, examples, and docs

### DIFF
--- a/IEnumerable-Extensions.slnx
+++ b/IEnumerable-Extensions.slnx
@@ -28,6 +28,12 @@
     <Project Path="benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/examples/">
+    <Project Path="examples/ForEach.Example/ForEach.Example.csproj" />
+    <Project Path="examples/Do.Example/Do.Example.csproj" />
+    <Project Path="examples/IsEmpty.Example/IsEmpty.Example.csproj" />
+    <Project Path="examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj" />
+    <Project Path="examples/None.Example/None.Example.csproj" />
+    <Project Path="examples/Shuffle.Example/Shuffle.Example.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj" />

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of extension methods for types that implement `IEnumerable<T>`.
 ## Methods
 
 - `ForEach<T>`: Executes the specified action on each item in the enumerable.
+- `Do<T>`: Executes a side-effect action on each element and yields items unchanged (passthrough).
 - `IsEmpty<T>`: Gets a value indicating whether a sequence contains no elements.
 - `IsNullOrEmpty<T>`: Gets a value indicating whether a sequence is null or contains no elements.
 - `None<T>()`: Determines whether a sequence contains no elements.

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -1,1 +1,62 @@
 # Getting Started
+
+This guide will help you install and start using Wolfgang.Extensions.IEnumerable in your .NET projects.
+
+## Installation
+
+### Via NuGet Package Manager
+
+```bash
+dotnet add package Wolfgang.Extensions.IEnumerable
+```
+
+## Basic Usage
+
+Add the using directive to your code:
+
+```csharp
+using Wolfgang.Extensions.IEnumerable;
+```
+
+### ForEach - Terminal Iteration
+
+```csharp
+var numbers = new[] { 1, 2, 3, 4, 5 };
+numbers.ForEach(n => Console.WriteLine(n));
+```
+
+### Do - Passthrough Side Effects
+
+```csharp
+var results = items
+    .Do(x => Console.WriteLine($"Processing: {x}"))
+    .Where(x => x.IsActive)
+    .ToList();
+```
+
+### IsEmpty / IsNullOrEmpty
+
+```csharp
+if (items.IsEmpty())
+{
+    Console.WriteLine("No items found");
+}
+
+IEnumerable<string>? data = GetData();
+if (data.IsNullOrEmpty())
+{
+    Console.WriteLine("Data is null or empty");
+}
+```
+
+### None - Inverse of Any
+
+```csharp
+bool noNegatives = numbers.None(n => n < 0);
+```
+
+### Shuffle - Randomize Order
+
+```csharp
+var shuffled = deck.Shuffle();
+```

--- a/docfx_project/docs/introduction.md
+++ b/docfx_project/docs/introduction.md
@@ -1,1 +1,28 @@
 # Introduction
+
+**Wolfgang.Extensions.IEnumerable** is a .NET library that provides a collection of useful extension methods for types that implement `IEnumerable<T>`.
+
+## Available Extension Methods
+
+### ForEach
+Executes the specified action on each item in the enumerable. This is a terminal operation that consumes the sequence.
+
+### Do
+Executes a side-effect action on each element without transforming the elements. The original items are yielded unchanged, making it ideal for logging, metrics, or debugging within a pipeline.
+
+### IsEmpty
+Efficiently determines whether a sequence contains no elements, with optimizations for `ICollection<T>`.
+
+### IsNullOrEmpty
+Safely checks whether a sequence is null or contains no elements in a single operation.
+
+### None (Two Overloads)
+- **None()**: Determines whether a sequence contains no elements (inverse of `Any()`)
+- **None(predicate)**: Determines whether no element of a sequence satisfies a condition (inverse of `Any(predicate)`)
+
+### Shuffle
+Creates a new `IEnumerable<T>` containing the elements from the source in a random order using the Fisher-Yates shuffle algorithm.
+
+## Getting Started
+
+To start using Wolfgang.Extensions.IEnumerable, see the [Getting Started](getting-started.md) guide for installation instructions and basic examples.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ using Wolfgang.Extensions.IEnumerable;
 
 ### Examples
 
-#### ForEach - Iterate with Actions
+#### ForEach - Terminal Iteration with Actions
 
 ```csharp
 var numbers = new[] { 1, 2, 3, 4, 5 };
@@ -51,11 +51,29 @@ numbers.ForEach(n => Console.WriteLine(n));
 
 // Execute complex actions
 var users = GetUsers();
-users.ForEach(user => 
+users.ForEach(user =>
 {
     user.IsActive = true;
     user.LastUpdated = DateTime.Now;
 });
+```
+
+#### Do - Passthrough Side Effects
+
+```csharp
+// Log each item as it flows through a pipeline
+var results = items
+    .Where(x => x.IsActive)
+    .Do(x => Console.WriteLine($"Processing: {x.Name}"))
+    .Select(x => x.Transform())
+    .ToList();
+
+// Chain multiple Do calls for debugging
+var output = data
+    .Do(x => logger.LogDebug($"Before filter: {x}"))
+    .Where(x => x.Value > 0)
+    .Do(x => logger.LogDebug($"After filter: {x}"))
+    .ToList();
 ```
 
 #### IsEmpty - Check for Empty Collections
@@ -124,6 +142,7 @@ All extension methods can be chained with LINQ and other extension methods:
 ```csharp
 var numbers = Enumerable.Range(1, 100)
     .Where(n => n % 2 == 0)
+    .Do(n => Console.WriteLine($"Filtered: {n}"))
     .Shuffle()
     .Take(10);
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,7 +17,10 @@ The library addresses common scenarios when working with collections in .NET tha
 ## Available Extension Methods
 
 ### ForEach
-Executes the specified action on each item in the enumerable, providing a more functional approach to iteration with side effects.
+Executes the specified action on each item in the enumerable, providing a more functional approach to iteration with side effects. This is a terminal operation that consumes the sequence.
+
+### Do
+Executes a side-effect action on each element without transforming the elements. The original items are yielded unchanged, making it ideal for logging, metrics, or debugging within a pipeline.
 
 ### IsEmpty
 Efficiently determines whether a sequence contains no elements, with optimizations for common collection types.

--- a/examples/Do.Example/Do.Example.csproj
+++ b/examples/Do.Example/Do.Example.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/examples/Do.Example/Program.cs
+++ b/examples/Do.Example/Program.cs
@@ -1,0 +1,43 @@
+using Wolfgang.Extensions.IEnumerable;
+
+// Do executes a side-effect action on each element and yields items unchanged.
+// Unlike ForEach, Do is a passthrough — items flow through the pipeline.
+
+Console.WriteLine("=== Do Example ===");
+Console.WriteLine();
+
+// Logging items as they flow through a pipeline
+var numbers = Enumerable.Range(1, 10);
+
+Console.WriteLine("Pipeline with Do for logging:");
+var evenNumbers = numbers
+    .Do(n => Console.WriteLine($"  Before filter: {n}"))
+    .Where(n => n % 2 == 0)
+    .Do(n => Console.WriteLine($"  After filter:  {n}"))
+    .ToList();
+
+Console.WriteLine($"Result: {string.Join(", ", evenNumbers)}");
+Console.WriteLine();
+
+// Counting items mid-pipeline without consuming the sequence
+var count = 0;
+var products = new[] { "Widget", "Gadget", "Doohickey", "Thingamajig" };
+
+var upperProducts = products
+    .Do(_ => count++)
+    .Select(p => p.ToUpperInvariant())
+    .ToList();
+
+Console.WriteLine($"Processed {count} products: {string.Join(", ", upperProducts)}");
+Console.WriteLine();
+
+// Chaining multiple Do calls for step-by-step debugging
+var result = Enumerable.Range(1, 5)
+    .Do(n => Console.WriteLine($"  Step 1 - Raw:       {n}"))
+    .Select(n => n * 3)
+    .Do(n => Console.WriteLine($"  Step 2 - Tripled:   {n}"))
+    .Where(n => n > 6)
+    .Do(n => Console.WriteLine($"  Step 3 - Filtered:  {n}"))
+    .ToList();
+
+Console.WriteLine($"Final result: {string.Join(", ", result)}");

--- a/examples/ForEach.Example/ForEach.Example.csproj
+++ b/examples/ForEach.Example/ForEach.Example.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/examples/ForEach.Example/Program.cs
+++ b/examples/ForEach.Example/Program.cs
@@ -1,0 +1,44 @@
+using Wolfgang.Extensions.IEnumerable;
+
+// ForEach executes an action on each item in the enumerable.
+// It is a terminal operation — it consumes the sequence and returns void.
+
+Console.WriteLine("=== ForEach Example ===");
+Console.WriteLine();
+
+// Basic usage: print each item
+var fruits = new[] { "Apple", "Banana", "Cherry", "Date" };
+
+Console.WriteLine("Printing each fruit:");
+fruits.ForEach(fruit => Console.WriteLine($"  - {fruit}"));
+Console.WriteLine();
+
+// Accumulating results with a side effect
+var numbers = new[] { 1, 2, 3, 4, 5 };
+var doubled = new List<int>();
+
+numbers.ForEach(n => doubled.Add(n * 2));
+
+Console.WriteLine("Original numbers: " + string.Join(", ", numbers));
+Console.WriteLine("Doubled numbers:  " + string.Join(", ", doubled));
+Console.WriteLine();
+
+// Using ForEach to update objects in place
+var users = new List<User>
+{
+    new() { Name = "Alice", IsActive = false },
+    new() { Name = "Bob", IsActive = false },
+    new() { Name = "Charlie", IsActive = false },
+};
+
+users.ForEach(u => u.IsActive = true);
+
+Console.WriteLine("After activating all users:");
+users.ForEach(u => Console.WriteLine($"  {u.Name}: Active = {u.IsActive}"));
+
+internal class User
+{
+    public string Name { get; set; } = "";
+
+    public bool IsActive { get; set; }
+}

--- a/examples/IsEmpty.Example/IsEmpty.Example.csproj
+++ b/examples/IsEmpty.Example/IsEmpty.Example.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/examples/IsEmpty.Example/Program.cs
+++ b/examples/IsEmpty.Example/Program.cs
@@ -1,0 +1,44 @@
+using Wolfgang.Extensions.IEnumerable;
+
+// IsEmpty checks whether a sequence contains no elements.
+// It is optimized for ICollection<T> types, using Count instead of enumerating.
+
+Console.WriteLine("=== IsEmpty Example ===");
+Console.WriteLine();
+
+// Check an empty list
+var emptyList = new List<string>();
+Console.WriteLine($"Empty list is empty: {emptyList.IsEmpty()}");
+
+// Check a populated list
+var populatedList = new List<string> { "Hello", "World" };
+Console.WriteLine($"Populated list is empty: {populatedList.IsEmpty()}");
+Console.WriteLine();
+
+// Use with LINQ query results
+var numbers = new[] { 1, 2, 3, 4, 5 };
+
+var bigNumbers = numbers.Where(n => n > 100);
+Console.WriteLine($"Numbers > 100 is empty: {bigNumbers.IsEmpty()}");
+
+var evenNumbers = numbers.Where(n => n % 2 == 0);
+Console.WriteLine($"Even numbers is empty: {evenNumbers.IsEmpty()}");
+Console.WriteLine();
+
+// Practical example: early return when no results
+var searchResults = SearchProducts("nonexistent");
+
+if (searchResults.IsEmpty())
+{
+    Console.WriteLine("No products found matching your search.");
+}
+else
+{
+    searchResults.ForEach(p => Console.WriteLine($"  Found: {p}"));
+}
+
+static IEnumerable<string> SearchProducts(string query)
+{
+    var products = new[] { "Widget", "Gadget", "Doohickey" };
+    return products.Where(p => p.Contains(query, StringComparison.OrdinalIgnoreCase));
+}

--- a/examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj
+++ b/examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/examples/IsNullOrEmpty.Example/Program.cs
+++ b/examples/IsNullOrEmpty.Example/Program.cs
@@ -1,0 +1,39 @@
+using Wolfgang.Extensions.IEnumerable;
+
+// IsNullOrEmpty safely checks whether a sequence is null or contains no elements.
+// Unlike IsEmpty, it does NOT throw on null — it returns true instead.
+
+Console.WriteLine("=== IsNullOrEmpty Example ===");
+Console.WriteLine();
+
+// Null reference
+IEnumerable<string>? nullCollection = null;
+Console.WriteLine($"Null collection: {nullCollection.IsNullOrEmpty()}");
+
+// Empty collection
+var emptyCollection = Array.Empty<string>();
+Console.WriteLine($"Empty collection: {emptyCollection.IsNullOrEmpty()}");
+
+// Populated collection
+var populatedCollection = new[] { "one", "two", "three" };
+Console.WriteLine($"Populated collection: {populatedCollection.IsNullOrEmpty()}");
+Console.WriteLine();
+
+// Practical example: guard clause in a method
+ProcessOrders(null);
+ProcessOrders(Array.Empty<Order>());
+ProcessOrders(new[] { new Order("ORD-001", 29.99m), new Order("ORD-002", 49.99m) });
+
+static void ProcessOrders(IEnumerable<Order>? orders)
+{
+    if (orders.IsNullOrEmpty())
+    {
+        Console.WriteLine("No orders to process.");
+        return;
+    }
+
+    Console.WriteLine("Processing orders:");
+    orders.ForEach(o => Console.WriteLine($"  {o.Id}: ${o.Amount}"));
+}
+
+internal record Order(string Id, decimal Amount);

--- a/examples/None.Example/None.Example.csproj
+++ b/examples/None.Example/None.Example.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/examples/None.Example/Program.cs
+++ b/examples/None.Example/Program.cs
@@ -1,0 +1,50 @@
+using Wolfgang.Extensions.IEnumerable;
+
+// None is the inverse of Any.
+// None() returns true if the sequence has no elements.
+// None(predicate) returns true if no elements match the predicate.
+
+Console.WriteLine("=== None Example ===");
+Console.WriteLine();
+
+// None() — check if sequence is empty
+var emptyList = new List<int>();
+var numbers = new[] { 1, 2, 3, 4, 5 };
+
+Console.WriteLine($"Empty list has none: {emptyList.None()}");
+Console.WriteLine($"Numbers has none: {numbers.None()}");
+Console.WriteLine();
+
+// None(predicate) — check if no elements match a condition
+Console.WriteLine($"None divisible by 3: {numbers.None(n => n % 3 == 0)}");
+Console.WriteLine($"None greater than 10: {numbers.None(n => n > 10)}");
+Console.WriteLine($"None negative: {numbers.None(n => n < 0)}");
+Console.WriteLine();
+
+// Practical example: validation
+var users = new[]
+{
+    new User("Alice", "alice@example.com", IsVerified: true),
+    new User("Bob", "bob@example.com", IsVerified: true),
+    new User("Charlie", "charlie@example.com", IsVerified: true),
+};
+
+if (users.None(u => !u.IsVerified))
+{
+    Console.WriteLine("All users are verified — ready to proceed.");
+}
+else
+{
+    Console.WriteLine("Some users are not yet verified.");
+}
+
+// Compare with Any — None reads more naturally in some cases
+var errors = new List<string>();
+
+// Instead of: if (!errors.Any())
+if (errors.None())
+{
+    Console.WriteLine("No errors found — validation passed.");
+}
+
+internal record User(string Name, string Email, bool IsVerified);

--- a/examples/Shuffle.Example/Program.cs
+++ b/examples/Shuffle.Example/Program.cs
@@ -1,0 +1,41 @@
+using Wolfgang.Extensions.IEnumerable;
+
+// Shuffle creates a new IEnumerable<T> with elements in random order.
+// It uses the Fisher-Yates shuffle algorithm and is thread-safe.
+
+Console.WriteLine("=== Shuffle Example ===");
+Console.WriteLine();
+
+// Basic shuffle
+var cards = new[] { "Ace", "King", "Queen", "Jack", "10", "9", "8", "7" };
+
+Console.WriteLine("Original order: " + string.Join(", ", cards));
+Console.WriteLine("Shuffled:       " + string.Join(", ", cards.Shuffle()));
+Console.WriteLine("Shuffled again:  " + string.Join(", ", cards.Shuffle()));
+Console.WriteLine();
+
+// Original collection is unchanged
+Console.WriteLine("Original still:  " + string.Join(", ", cards));
+Console.WriteLine();
+
+// Practical example: randomize quiz questions
+var questions = new[]
+{
+    "What is the capital of France?",
+    "What year did the moon landing occur?",
+    "What is the speed of light?",
+    "Who wrote Hamlet?",
+    "What is the chemical symbol for gold?",
+};
+
+Console.WriteLine("Quiz questions in random order:");
+var questionNumber = 1;
+questions.Shuffle().ForEach(q => Console.WriteLine($"  {questionNumber++}. {q}"));
+Console.WriteLine();
+
+// Chain with LINQ
+var topThree = Enumerable.Range(1, 20)
+    .Shuffle()
+    .Take(3);
+
+Console.WriteLine("3 random numbers from 1-20: " + string.Join(", ", topThree));

--- a/examples/Shuffle.Example/Shuffle.Example.csproj
+++ b/examples/Shuffle.Example/Shuffle.Example.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -18,6 +18,12 @@ public static class IEnumerableExtensions
     /// <param name="source">An IEnumerable{T} whose elements the action will be executed on.</param>
     /// <param name="action">The action to execute on each item in the enumerable</param>
     /// <exception cref="ArgumentNullException">source is null.</exception>
+    /// <example>
+    /// <code>
+    /// var numbers = new[] { 1, 2, 3, 4, 5 };
+    /// numbers.ForEach(n => Console.WriteLine(n));
+    /// </code>
+    /// </example>
     public static void ForEach<T>(this IEnumerable<T>? source, Action<T> action)
     {
         if (source == null)
@@ -54,6 +60,12 @@ public static class IEnumerableExtensions
     /// <returns>
     /// true if the source sequence contains no elements; otherwise, false.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// var items = new List&lt;string&gt;();
+    /// Console.WriteLine(items.IsEmpty()); // Prints true
+    /// </code>
+    /// </example>
     public static bool IsEmpty<T>(this IEnumerable<T>? source)
     {
         if (source == null)
@@ -79,6 +91,12 @@ public static class IEnumerableExtensions
     /// <returns>
     /// true if the source sequence is null or contains no elements; otherwise, false.
     /// </returns>
+    /// <example>
+    /// <code>
+    /// IEnumerable&lt;string&gt;? data = null;
+    /// Console.WriteLine(data.IsNullOrEmpty()); // Prints true
+    /// </code>
+    /// </example>
     public static bool IsNullOrEmpty<T>(this IEnumerable<T>? source)
         => source == null || !source.Any();
 
@@ -156,12 +174,63 @@ public static class IEnumerableExtensions
 
 
     /// <summary>
+    /// Executes a side-effect action on each element of an IEnumerable{T}
+    /// without transforming the elements. The original items are yielded unchanged.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements of source.</typeparam>
+    /// <param name="source">An IEnumerable{T} whose elements the action will be executed on.</param>
+    /// <param name="action">The action to execute on each element.</param>
+    /// <returns>An IEnumerable{T} that yields the original elements after executing the action.</returns>
+    /// <exception cref="ArgumentNullException">source or action is null.</exception>
+    /// <example>
+    /// <code>
+    /// foreach (var item in source.Do(x => Console.WriteLine($"Processing: {x}")))
+    /// {
+    ///     // item is unchanged
+    /// }
+    /// </code>
+    /// </example>
+    public static IEnumerable<T> Do<T>(this IEnumerable<T>? source, Action<T> action)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (action == null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return DoIterator(source, action);
+    }
+
+
+
+    private static IEnumerable<T> DoIterator<T>(IEnumerable<T> source, Action<T> action)
+    {
+        foreach (var item in source)
+        {
+            action(item);
+            yield return item;
+        }
+    }
+
+
+
+    /// <summary>
     /// Creates a new IEnumerable{T} containing the elements from source in a random order
     /// </summary>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An IEnumerable{T} whose elements will be randomly ordered.</param>
     /// <returns>A new IEnumerable{T} containing the elements from source in a random order.</returns>
     /// <exception cref="ArgumentNullException">source is null.</exception>
+    /// <example>
+    /// <code>
+    /// var deck = new[] { "Ace", "King", "Queen", "Jack" };
+    /// var shuffled = deck.Shuffle();
+    /// </code>
+    /// </example>
     public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
     {
         if (source == null)

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -8,7 +8,7 @@
 		</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>1.0.0</Version>
+		<Version>1.1.0</Version>
 		<Title>$(AssemblyName)</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A collection of extension methods for types that implement IEnumerable</Description>

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/DoTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/DoTests.cs
@@ -1,0 +1,149 @@
+namespace Wolfgang.Extensions.IEnumerable.Tests.Unit;
+
+public class DoTests
+{
+
+    [Fact]
+    public void Do_when_source_is_null_throws_ArgumentNullException()
+    {
+        IEnumerable<int> source = null!;
+
+        var exception = Assert.Throws<ArgumentNullException>(() => source.Do(_ => { }).ToList());
+
+        Assert.Equal("source", exception.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Do_when_action_is_null_throws_ArgumentNullException()
+    {
+        var source = new[] { 1, 2, 3 };
+
+        var exception = Assert.Throws<ArgumentNullException>(() => source.ToEnumerable().Do(null!).ToList());
+
+        Assert.Equal("action", exception.ParamName);
+    }
+
+
+
+    [Fact]
+    public void Do_when_source_has_items_executes_action_on_each()
+    {
+        var source = new[] { 1, 2, 3 };
+        var observed = new List<int>();
+
+        var result = source.ToEnumerable().Do(x => observed.Add(x)).ToList();
+
+        Assert.Equal(new[] { 1, 2, 3 }, observed);
+        Assert.Equal(new[] { 1, 2, 3 }, result);
+    }
+
+
+
+    [Fact]
+    public void Do_when_source_is_empty_executes_no_actions()
+    {
+        var source = new int[] { };
+        var observed = new List<int>();
+
+        var result = source.ToEnumerable().Do(x => observed.Add(x)).ToList();
+
+        Assert.Empty(observed);
+        Assert.Empty(result);
+    }
+
+
+
+    [Fact]
+    public void Do_yields_original_items_unchanged()
+    {
+        var source = new[] { 10, 20, 30 };
+
+        var result = source.ToEnumerable().Do(_ => { }).ToList();
+
+        Assert.Equal(new[] { 10, 20, 30 }, result);
+    }
+
+
+
+    [Fact]
+    public void Do_preserves_ordering()
+    {
+        var source = new[] { 5, 3, 1, 4, 2 };
+        var observed = new List<int>();
+
+        var result = source.ToEnumerable().Do(x => observed.Add(x)).ToList();
+
+        Assert.Equal(new[] { 5, 3, 1, 4, 2 }, observed);
+        Assert.Equal(new[] { 5, 3, 1, 4, 2 }, result);
+    }
+
+
+
+    [Fact]
+    public void Do_does_not_enumerate_source_until_consumed()
+    {
+        var enumerated = false;
+        var source = CreateTrackingEnumerable(() => enumerated = true, 1, 2, 3);
+
+        var tapped = source.Do(_ => { });
+
+        Assert.False(enumerated);
+
+        tapped.ToList();
+
+        Assert.True(enumerated);
+    }
+
+
+
+    [Fact]
+    public void Do_executes_action_before_yielding_item()
+    {
+        var source = new[] { 1, 2, 3 };
+        var log = new List<string>();
+
+        foreach (var item in source.ToEnumerable().Do(x => log.Add($"action:{x}")))
+        {
+            log.Add($"yield:{item}");
+        }
+
+        Assert.Equal
+        (
+            new[] { "action:1", "yield:1", "action:2", "yield:2", "action:3", "yield:3" },
+            log
+        );
+    }
+
+
+
+    [Fact]
+    public void Do_when_action_throws_propagates_exception()
+    {
+        var source = new[] { 1, 2, 3 };
+
+        Assert.Throws<InvalidOperationException>
+        (
+            () => source.ToEnumerable().Do(x =>
+            {
+                if (x == 2)
+                {
+                    throw new InvalidOperationException("test");
+                }
+            }).ToList()
+        );
+    }
+
+
+
+    private static IEnumerable<T> CreateTrackingEnumerable<T>(Action onEnumerate, params T[] values)
+    {
+        onEnumerate();
+        foreach (var value in values)
+        {
+            yield return value;
+        }
+    }
+
+}

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
@@ -57,4 +57,18 @@ public class ForEachTests
         Assert.Equal(expected, result);
     }
 
+
+
+    [Fact]
+    public void ForEach_when_source_is_List_cast_as_IEnumerable_uses_List_ForEach()
+    {
+        IEnumerable<int> source = new List<int> { 1, 2, 3, 4, 5 };
+        var result = new List<int>();
+
+        source.ForEach(i => result.Add(i * 2));
+
+        var expected = new[] { 2, 4, 6, 8, 10 };
+        Assert.Equal(expected, result);
+    }
+
 }


### PR DESCRIPTION
## Summary
- Add `Do<T>` passthrough extension method for pipeline side-effects (yields items unchanged after executing an action)
- Add XML doc `<example>` blocks to `ForEach`, `IsEmpty`, `IsNullOrEmpty`, and `Shuffle` (previously missing)
- Add test for `List<T>` fast-path in `ForEach` to achieve 100% line coverage
- Add 6 example console projects (one per method): `ForEach`, `Do`, `IsEmpty`, `IsNullOrEmpty`, `None`, `Shuffle`
- Update README, introduction, and getting-started documentation with `Do` method
- Bump version from 1.0.0 to 1.1.0

## Test plan
- [x] All 41 tests pass in Release mode on net8.0
- [x] 100% line coverage, 96.8% branch coverage
- [x] All 6 example projects build and run successfully
- [x] No warnings in Release build

🤖 Generated with [Claude Code](https://claude.com/claude-code)