### PR TITLE
Replace release.yaml with repo-template standard

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,20 +1,27 @@
-name: Release on Version Tag
+name: Release on Published Release
+
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 permissions:
-  contents: read
+  contents: read  # Default to read-only; individual jobs declare write where required
+
+env:
+  CODECOV_MINIMUM: 90
 
 jobs:
-  build-and-test:
-    name: Build and Test
+  # Streamlined validation: All frameworks, Windows only
+  validate-release:
+    name: Validate Release Build
     runs-on: windows-latest
+    if: github.repository != 'Chris-Wolfgang/repo-template'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -33,32 +40,261 @@ jobs:
       - name: Build Solution (Release)
         run: dotnet build --no-restore --configuration Release
 
-      - name: Run tests for all test projects
+      - name: Run multi-framework tests with coverage
         shell: pwsh
         run: |
-          Get-ChildItem -Path './tests' -Recurse -Filter '*Test*.csproj' | ForEach-Object {
-            Write-Host "Running tests for $($_.FullName)"
-            dotnet test $_.FullName --no-build --configuration Release
-            if ($LASTEXITCODE -ne 0) {
-              Write-Error "Tests failed for $($_.FullName)"
-              exit $LASTEXITCODE
+          $testProjects = Get-ChildItem -Path './tests' -Recurse -Filter '*Test*.csproj'
+          
+          if ($testProjects.Count -eq 0) {
+            Write-Error "❌ No test projects found - release requires tests to validate quality"
+            exit 1
+          }
+          
+          foreach ($testProj in $testProjects) {
+            Write-Host "==========================================" -ForegroundColor Cyan
+            Write-Host "Testing project: $($testProj.Name)" -ForegroundColor Cyan
+            Write-Host "==========================================" -ForegroundColor Cyan
+            
+            # Parse the project file to extract target frameworks
+            try {
+              [xml]$projectXml = Get-Content $testProj.FullName
+            } catch {
+              Write-Error "❌ Failed to parse project file $($testProj.Name): $_"
+              exit 1
+            }
+            
+            # Search all PropertyGroup elements for TargetFramework(s)
+            $targetFramework = $null
+            $targetFrameworks = $null
+            foreach ($propGroup in $projectXml.Project.PropertyGroup) {
+              if ($propGroup.TargetFrameworks) {
+                $targetFrameworks = $propGroup.TargetFrameworks
+                break
+              } elseif ($propGroup.TargetFramework) {
+                $targetFramework = $propGroup.TargetFramework
+                break
+              }
+            }
+            
+            # Determine which frameworks this project targets
+            $frameworks = @()
+            if ($targetFrameworks) {
+              # Multiple frameworks (semicolon-separated)
+              $frameworks = $targetFrameworks -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+              if ($frameworks.Count -eq 0) {
+                Write-Error "❌ TargetFrameworks property in $($testProj.Name) is empty or malformed"
+                exit 1
+              }
+            } elseif ($targetFramework) {
+              # Single framework
+              $frameworks = @($targetFramework.Trim())
+              if (-not $frameworks[0]) {
+                Write-Error "❌ TargetFramework property in $($testProj.Name) is empty"
+                exit 1
+              }
+            } else {
+              # If no TargetFramework/TargetFrameworks are defined directly in the project file,
+              # attempt to resolve them via MSBuild (to account for Directory.Build.props, imports, etc.).
+              Write-Host "No TargetFramework or TargetFrameworks found directly in $($testProj.Name); querying MSBuild..." -ForegroundColor Yellow
+              
+              $msbuildOutput = @()
+              $msbuildExitCode = 0
+              foreach ($prop in @("TargetFrameworks", "TargetFramework")) {
+                $result = dotnet msbuild $testProj.FullName /nologo "-getProperty:$prop" 2>&1
+                if ($LASTEXITCODE -ne 0) {
+                  $msbuildExitCode = $LASTEXITCODE
+                }
+                if ($result) {
+                  $msbuildOutput += $result
+                }
+              }
+              
+              if ($msbuildExitCode -ne 0) {
+                # MSBuild query failed, fall back to running tests without explicit --framework
+                Write-Warning "MSBuild query failed for $($testProj.Name). Tests will run without explicit --framework."
+                $frameworks = @('')
+              } else {
+                # MSBuild succeeded, parse the output
+                $resolvedFrameworks = @()
+                foreach ($line in $msbuildOutput) {
+                  if ([string]::IsNullOrWhiteSpace($line)) {
+                    continue
+                  }
+                  
+                  # Expect lines like "TargetFrameworks=net7.0;net8.0" or "TargetFramework=net8.0"
+                  # Support both '=' and ':' separators for different MSBuild output formats
+                  if ($line -match '^\s*TargetFrameworks\s*[:=]\s*(.+)$') {
+                    $propertyValue = $Matches[1].Trim()
+                    $resolvedFrameworks = $propertyValue -split ';' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+                    break
+                  } elseif ($line -match '^\s*TargetFramework\s*[:=]\s*(.+)$') {
+                    $propertyValue = $Matches[1].Trim()
+                    if ($propertyValue) {
+                      $resolvedFrameworks = @($propertyValue)
+                    }
+                    
+                    if ($resolvedFrameworks.Count -gt 0) {
+                      break
+                    }
+                  }
+                }
+                
+                if ($resolvedFrameworks.Count -gt 0) {
+                  $frameworks = $resolvedFrameworks
+                } else {
+                  Write-Warning "MSBuild query returned no target frameworks for $($testProj.Name). Tests will run without explicit --framework."
+                  $frameworks = @('')
+                }
+              }
+            }
+            
+            Write-Host "Detected frameworks: $($frameworks -join ', ')" -ForegroundColor Cyan
+            
+            foreach ($fw in $frameworks) {
+              if ([string]::IsNullOrWhiteSpace($fw)) {
+                Write-Host "Testing project $($testProj.Name) without explicit --framework (using SDK/MSBuild defaults)" -ForegroundColor Yellow
+                
+                # When framework cannot be determined, run tests once without specifying --framework.
+                # Collect coverage in this case to avoid missing data due to unknown TFM.
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --no-build `
+                  --no-restore `
+                  --collect:"XPlat Code Coverage" `
+                  --results-directory "./TestResults" `
+                  --logger "console;verbosity=minimal"
+                
+                if ($LASTEXITCODE -ne 0) {
+                  Write-Error "❌ Tests failed (no explicit TargetFramework) in $($testProj.Name)"
+                  exit $LASTEXITCODE
+                }
+                
+                continue
+              }
+              
+              Write-Host "Testing framework: $fw" -ForegroundColor Yellow
+              
+              # Collect coverage only for .NET 5.0+ TFMs; still run tests for all frameworks
+              if ($fw -match '^net([5-9]|[1-9][0-9]+)\.') {
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --framework $fw `
+                  --no-build `
+                  --no-restore `
+                  --collect:"XPlat Code Coverage" `
+                  --results-directory "./TestResults" `
+                  --logger "console;verbosity=minimal"
+              } else {
+                # For older frameworks (e.g., netstandard, net4x, net3x, etc.), run tests without coverage
+                dotnet test $testProj.FullName `
+                  --configuration Release `
+                  --framework $fw `
+                  --no-build `
+                  --no-restore `
+                  --results-directory "./TestResults" `
+                  --logger "console;verbosity=minimal"
+              }
+              
+              if ($LASTEXITCODE -ne 0) {
+                if ($fw) {
+                  Write-Error "❌ Tests failed for $fw in $($testProj.Name)"
+                } else {
+                  Write-Error "❌ Tests failed in $($testProj.Name)"
+                }
+                exit $LASTEXITCODE
+              }
+            }
+            Write-Host ""
+          }
+          Write-Host "✅ All framework tests passed" -ForegroundColor Green
+
+      - name: Verify coverage threshold
+        shell: pwsh
+        run: |
+          # Check if coverage files exist
+          $coverageFiles = Get-ChildItem -Path "TestResults" -Recurse -Filter "coverage.cobertura.xml" -ErrorAction SilentlyContinue
+          
+          if ($coverageFiles.Count -eq 0) {
+            Write-Error "❌ No coverage files found - coverage data is required to enforce the 90% threshold"
+            exit 1
+          }
+          
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+          
+          reportgenerator `
+            -reports:"TestResults/**/coverage.cobertura.xml" `
+            -targetdir:"CoverageReport" `
+            -reporttypes:"TextSummary;Html"
+          
+          Write-Host "==========================================" -ForegroundColor Cyan
+          Write-Host "Coverage Summary:" -ForegroundColor Cyan
+          Write-Host "==========================================" -ForegroundColor Cyan
+          Get-Content CoverageReport/Summary.txt
+          Write-Host ""
+          
+          # Parse coverage and enforce threshold per module (matching pr.yaml)
+          $summaryContent = Get-Content CoverageReport/Summary.txt
+          $threshold = if ($env:CODECOV_MINIMUM) { [int]$env:CODECOV_MINIMUM } else { 90 }
+          $failedModules = @()
+          $coverageFound = $false
+          
+          foreach ($line in $summaryContent) {
+            # Match lines with module names and percentages (skip Summary line)
+            if ($line -match '^([^ ]+)\s+.*\s+(\d+(?:\.\d+)?)%$' -and $line -notmatch '^Summary') {
+              $coverageFound = $true
+              $module = $matches[1]
+              $coverage = [decimal]$matches[2]
+              
+              Write-Host "Checking module: '$module' - Coverage: ${coverage}%" -ForegroundColor Cyan
+              
+              if ($coverage -lt $threshold) {
+                Write-Host "  ❌ FAIL: Below ${threshold}% threshold" -ForegroundColor Red
+                $failedModules += "$module (${coverage}%)"
+              } else {
+                Write-Host "  ✅ PASS: Meets ${threshold}% threshold" -ForegroundColor Green
+              }
             }
           }
+          
+          # Ensure we found and parsed coverage data
+          if (-not $coverageFound) {
+            Write-Error "❌ Failed to parse coverage data from Summary.txt - cannot enforce threshold"
+            exit 1
+          }
+          
+          if ($failedModules.Count -gt 0) {
+            Write-Host ""
+            Write-Host "==========================================" -ForegroundColor Red
+            Write-Host "❌ COVERAGE GATE FAILED" -ForegroundColor Red
+            Write-Host "==========================================" -ForegroundColor Red
+            Write-Host "Modules below ${threshold}% coverage: $($failedModules -join ', ')" -ForegroundColor Red
+            exit 1
+          }
+          
+          Write-Host ""
+          Write-Host "==========================================" -ForegroundColor Green
+          Write-Host "✅ All modules meet ${threshold}% coverage threshold" -ForegroundColor Green
+          Write-Host "==========================================" -ForegroundColor Green
 
-      - name: Upload test results
+      - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: '**/TestResults*.trx'
+          name: release-coverage
+          path: CoverageReport/
 
-  publish:
-    name: Pack and Publish NuGet
-    needs: build-and-test
+  # Pack and validate NuGet package
+  pack-and-validate:
+    name: Pack & Validate NuGet
+    needs: validate-release
     runs-on: windows-latest
+    outputs:
+      has-packages: ${{ steps.check-packages.outputs.has-packages }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
@@ -71,25 +307,166 @@ jobs:
             9.0.x
             10.0.x
 
-      - name: Restore dependencies
-        run: dotnet restore
+      - name: Restore and build
+        run: |
+          dotnet restore
+          dotnet build --no-restore --configuration Release
 
-      - name: Build Solution (Release)
-        run: dotnet build --no-restore --configuration Release
-
-      - name: Pack NuGet Packages
+      - name: Pack NuGet packages
+        id: check-packages
         shell: pwsh
         run: |
+          # Create output directory for NuGet packages
           $packagesPath = Join-Path $PWD 'nuget-packages'
           New-Item -ItemType Directory -Force -Path $packagesPath | Out-Null
 
-          Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj' | ForEach-Object {
-            Write-Host "Packing $($_.FullName)"
-            dotnet pack $_.FullName --no-build --configuration Release --output $packagesPath
+          # Find all .csproj files in the src directory recursively
+          $projects = Get-ChildItem -Path 'src' -Recurse -Filter '*.csproj'
+          
+          # Handle case when no projects are found (e.g., template repository)
+          if ($projects.Count -eq 0) {
+            Write-Warning "No projects found in src/ directory - skipping package creation"
+            Write-Warning "Downstream publish and release jobs will be skipped"
+            # Create empty directory for artifact upload
+            New-Item -ItemType File -Path (Join-Path $packagesPath '.placeholder') -Force | Out-Null
+            # Set output to indicate no packages were created
+            "has-packages=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            exit 0
+          }
+          
+          # Iterate through each project and create NuGet package
+          foreach ($proj in $projects) {
+            Write-Host "📦 Packing $($proj.Name)" -ForegroundColor Cyan
+            dotnet pack $proj.FullName --no-build --configuration Release --output $packagesPath
+            
+            # Check if pack operation failed and exit with error
             if ($LASTEXITCODE -ne 0) {
-              Write-Error "dotnet pack failed for $($_.FullName)"
+              Write-Error "❌ Pack failed for $($proj.Name)"
               exit $LASTEXITCODE
             }
+          }
+          
+          # Check whether any .nupkg files were actually created
+          $packages = Get-ChildItem -Path $packagesPath -Filter '*.nupkg' -ErrorAction SilentlyContinue
+          
+          if ($packages.Count -eq 0) {
+            Write-Warning "No .nupkg files were produced during packing - downstream publish and release jobs will be skipped"
+            "has-packages=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            exit 0
+          }
+          
+          # At least one package was created successfully
+          Write-Host "✅ NuGet packages created successfully" -ForegroundColor Green
+          "has-packages=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
+      - name: Smoke test NuGet package installation
+        shell: pwsh
+        run: |
+          $packages = Get-ChildItem -Path 'nuget-packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
+          
+          if ($packages.Count -eq 0) {
+            Write-Warning "No .nupkg files found - skipping smoke test"
+            exit 0
+          }
+          
+          # Helper to read package ID and version from the .nuspec inside a .nupkg
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          function Get-PackageMetadata {
+            param (
+              [Parameter(Mandatory = $true)]
+              [string] $NupkgPath
+            )
+
+            $zip = [System.IO.Compression.ZipFile]::OpenRead($NupkgPath)
+            try {
+              $nuspecEntry = $zip.Entries | Where-Object { $_.FullName -like '*.nuspec' } | Select-Object -First 1
+              if (-not $nuspecEntry) {
+                throw "No .nuspec file found in package '$NupkgPath'."
+              }
+
+              $stream = $nuspecEntry.Open()
+              try {
+                $reader = New-Object System.IO.StreamReader($stream)
+                $nuspecXml = [xml]$reader.ReadToEnd()
+                $id = $nuspecXml.package.metadata.id
+                $version = $nuspecXml.package.metadata.version
+
+                if ([string]::IsNullOrWhiteSpace($id) -or [string]::IsNullOrWhiteSpace($version)) {
+                  throw "Failed to read id/version from nuspec in '$NupkgPath'."
+                }
+
+                [PSCustomObject]@{
+                  Id      = $id
+                  Version = $version
+                }
+              }
+              finally {
+                $stream.Dispose()
+              }
+            }
+            finally {
+              $zip.Dispose()
+            }
+          }
+          
+          # Create temporary test project
+          $testDir = Join-Path $PWD 'package-smoke-test'
+          New-Item -ItemType Directory -Force -Path $testDir | Out-Null
+
+          # Restrict NuGet restores in this directory to the local package source only
+          $nugetConfigPath = Join-Path $testDir 'NuGet.config'
+          # Build NuGet.config content as array to avoid YAML parsing issues with here-strings
+          $nugetConfigContent = @(
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<configuration>'
+            '  <packageSources>'
+            '    <clear />'
+            '    <add key="local" value="../nuget-packages" />'
+            '  </packageSources>'
+            '  <packageSourceMapping>'
+            '    <packageSource key="local">'
+            '      <package pattern="*" />'
+            '    </packageSource>'
+            '  </packageSourceMapping>'
+            '</configuration>'
+          )
+          $nugetConfigContent | Set-Content -Path $nugetConfigPath -Encoding UTF8
+          
+          Push-Location $testDir
+          try {
+            dotnet new console -n SmokeTest -f net8.0
+            
+            # Try to install the newly created package(s)
+            foreach ($package in $packages) {
+              Write-Host "🧪 Smoke testing package: $($package.Name)" -ForegroundColor Yellow
+              
+              $metadata = Get-PackageMetadata -NupkgPath $package.FullName
+              $packageId = $metadata.Id
+              $packageVersion = $metadata.Version
+              
+              dotnet add SmokeTest/SmokeTest.csproj package $packageId --version $packageVersion --source '../nuget-packages'
+              
+              if ($LASTEXITCODE -ne 0) {
+                Write-Error "❌ Failed to install package $($package.Name)"
+                exit $LASTEXITCODE
+              }
+              
+              Write-Host "✅ Package $($package.Name) installed successfully" -ForegroundColor Green
+            }
+            
+            # Try to build the test project with the package
+            Write-Host "Building smoke test project..." -ForegroundColor Yellow
+            dotnet build SmokeTest/SmokeTest.csproj
+            
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "❌ Smoke test project failed to build with installed packages"
+              exit $LASTEXITCODE
+            }
+            
+            Write-Host "✅ Smoke test passed - packages are installable and buildable" -ForegroundColor Green
+            
+          } finally {
+            Pop-Location
           }
 
       - name: Generate SBOM (CycloneDX)
@@ -121,26 +498,125 @@ jobs:
           }
 
 
-      - name: Upload NuGet packages as artifacts
+      - name: Upload NuGet packages
         uses: actions/upload-artifact@v4
-        with: 
+        with:
           name: nuget-packages
-          path: ./nuget-packages/*.nupkg
-            ./nuget-packages/*.bom.json
-          retention-days: 30
+          path: ./nuget-packages/
+          retention-days: 90
+          if-no-files-found: warn
 
-      - name: Publish NuGet Package
+  # Publish to NuGet (only if validation passed)
+  publish-nuget:
+    name: Publish to NuGet.org
+    needs: pack-and-validate
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: windows-latest
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            5.0.x
+            6.0.x
+            7.0.x
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./packages
+
+      - name: Validate NuGet API key
         shell: pwsh
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
-          $packagesPath = Join-Path $PWD 'nuget-packages'
-          Get-ChildItem -Path $packagesPath -Filter '*.nupkg' | ForEach-Object {
-            ./nuget-packages/*.bom.json
-            Write-Host "Publishing $($_.FullName)"
-            dotnet nuget push $_.FullName --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+          if ([string]::IsNullOrEmpty($env:NUGET_API_KEY)) {
+            Write-Error "❌ NUGET_API_KEY secret not configured!"
+            Write-Host "Please add it in: Repository Settings → Secrets and variables → Actions → New repository secret"
+            exit 1
+          }
+          Write-Host "✅ NUGET_API_KEY is configured" -ForegroundColor Green
+
+      - name: Publish to NuGet
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          $packages = Get-ChildItem -Path './packages' -Filter '*.nupkg' -ErrorAction SilentlyContinue
+          
+          if ($packages.Count -eq 0) {
+            Write-Warning "No .nupkg files found - nothing to publish"
+            exit 0
+          }
+          
+          foreach ($package in $packages) {
+            Write-Host "📤 Publishing $($package.Name) to NuGet.org" -ForegroundColor Cyan
+            
+            dotnet nuget push $package.FullName `
+              --api-key $env:NUGET_API_KEY `
+              --source https://api.nuget.org/v3/index.json `
+              --skip-duplicate
+            
+            # Exit code 0 = success, 409 would be duplicate (handled by --skip-duplicate flag)
             if ($LASTEXITCODE -ne 0) {
-              Write-Error "dotnet nuget push failed for $($_.FullName)"
+              Write-Error "❌ Failed to publish $($package.Name)"
               exit $LASTEXITCODE
             }
+            
+            Write-Host "✅ Successfully published $($package.Name)" -ForegroundColor Green
           }
+          
+          Write-Host ""
+          Write-Host "==========================================" -ForegroundColor Green
+          Write-Host "✅ All packages published to NuGet.org" -ForegroundColor Green
+          Write-Host "==========================================" -ForegroundColor Green
+
+  # Build and deploy versioned documentation via the shared docfx workflow
+  # Note: reusable workflow jobs called via `uses:` do not require `runs-on` in the caller
+  trigger-docs:
+    name: Build & Deploy Documentation
+    needs: validate-release
+    permissions:
+      contents: write  # Required by docfx.yaml to push to gh-pages branch
+    uses: ./.github/workflows/docfx.yaml
+    with:
+      version: ${{ github.event.release.tag_name }}
+
+  # Attach NuGet packages and coverage report to the GitHub Release page
+  update-release-artifacts:
+    name: Attach Artifacts to Release
+    needs: [validate-release, pack-and-validate, publish-nuget]
+    if: needs.pack-and-validate.outputs.has-packages == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to upload assets to the GitHub Release
+    steps:
+      - name: Download NuGet packages artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./nuget-packages
+
+      - name: Download coverage report artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: release-coverage
+          path: ./release-coverage
+
+      - name: Zip coverage report
+        run: zip -r release-coverage.zip ./release-coverage
+
+      - name: Attach artifacts to release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b  # v2.5.0
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            ./nuget-packages/*.nupkg
+            ./nuget-packages/*.bom.json
+            release-coverage.zip
+


### PR DESCRIPTION
## Summary
Full replacement of the old "Release on Version Tag" workflow with the standard repo-template pipeline.

- **Trigger:** tag push → GitHub Release published event
- **Pipeline:** Multi-stage validated (validate → build/test → pack → publish → GitHub release)
- **New features:** NuGet smoke testing, CycloneDX SBOM, coverage reporting, security hardening
- **Security:** `persist-credentials: false`, SHA-pinned actions, repo-template guard

## Test plan
- [ ] Verify YAML parses cleanly
- [ ] Verify diff against repo-template is empty
- [ ] Test with a pre-release to confirm pipeline works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)