### PR TITLE
Add netcoreapp3.1 SDK to release.yaml setup-dotnet steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
+            3.1.x
             5.0.x
             6.0.x
             7.0.x


### PR DESCRIPTION
## Summary
- Added `3.1.x` to the `setup-dotnet` dotnet-version list in the `build-and-test` job of release.yaml
- The publish job's setup-dotnet was intentionally left unchanged since it only needs to pack and push NuGet packages

## Test plan
- [ ] Verify the release workflow passes on a version tag push with netcoreapp3.1 tests included

🤖 Generated with [Claude Code](https://claude.com/claude-code)