### PR TITLE
Require 'Detect .NET Projects' check in branch ruleset

### DIFF
--- a/scripts/Setup-BranchRuleset.ps1
+++ b/scripts/Setup-BranchRuleset.ps1
@@ -189,6 +189,9 @@ $rulesetConfig = @{
                 # and doesn't run for a PR, GitHub will treat the required check as missing and
                 # block the merge. All required status checks must run on every PR.
                 required_status_checks = @(
+                    # Gating job — fails when protected config files change, which would
+                    # otherwise cause Stage 1/2/3 to SKIP (not fail) and silently allow merge.
+                    @{ context = "Detect .NET Projects" },
                     @{ context = "Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate" },
                     @{ context = "Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" },
                     @{ context = "Stage 3: macOS Tests (.NET 6.0-10.0)" },
@@ -240,6 +243,7 @@ try {
             Write-Host "   ✅ No approvals required (single-developer mode)" -ForegroundColor Gray
         }
         Write-Host "   ✅ Required status checks (must pass before merging):" -ForegroundColor Gray
+        Write-Host "      - Detect .NET Projects" -ForegroundColor DarkGray
         Write-Host "      - Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate" -ForegroundColor DarkGray
         Write-Host "      - Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)" -ForegroundColor DarkGray
         Write-Host "      - Stage 3: macOS Tests (.NET 6.0-10.0)" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary
Fixes a merge-gating bypass where Dependabot PRs (or any PR modifying protected configuration files) appeared to have a failing CI check yet remained mergeable.

## Root cause
The \`detect-projects\` job runs a **"Detect protected configuration file changes"** step that exits 1 when a PR changes \`Directory.Build.props\`, \`.editorconfig\`, \`BannedSymbols.txt\`, etc. When that step fails:

1. The \`check-projects\` step never runs, so \`has-projects\` output is empty
2. Downstream Stage 1/2/3 jobs have \`if: ... && needs.detect-projects.outputs.has-projects == 'true'\` → condition is false → **jobs SKIP (not fail)**
3. Skipped required status checks are treated as neutral by branch protection
4. The PR is mergeable despite the visible \`exit code 1\`

## Fix
Add \`"Detect .NET Projects"\` as the first entry in \`required_status_checks\` so that a failure in that gating job directly blocks merge.

The live ruleset on this repo has **already been updated** via the GitHub API, so the fix is effective immediately. This PR brings \`Setup-BranchRuleset.ps1\` in sync so any future re-creation applies the same requirement.

## Verification
Live ruleset now reports:
\`\`\`
required_status_checks:
  - Detect .NET Projects          ← NEW
  - Stage 1: Linux Tests (.NET 5.0-10.0) + Coverage Gate
  - Stage 2: Windows Tests (.NET 5.0-10.0, Framework 4.6.2-4.8.1)
  - Stage 3: macOS Tests (.NET 6.0-10.0)
  - Security Scan (DevSkim)
\`\`\`

PRs like #64, #65 (Dependabot bumps to Directory.Build.props) will now be correctly blocked from merge while the detect job is failing.

## Test plan
- [x] Live ruleset updated via \`gh api -X PUT\`
- [x] Script matches the live state
- [ ] Re-verify Dependabot PRs show the Detect check as a blocking requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)