### PR TITLE
Document ArgumentNullException on IsEmpty<T> and use named arg in example

### DIFF
--- a/examples/IsNullOrEmpty.Example/Program.cs
+++ b/examples/IsNullOrEmpty.Example/Program.cs
@@ -20,7 +20,7 @@ Console.WriteLine($"Populated collection: {populatedCollection.IsNullOrEmpty()}"
 Console.WriteLine();
 
 // Practical example: guard clause in a method
-ProcessOrders(null);
+ProcessOrders(orders: null);
 ProcessOrders(Array.Empty<Order>());
 ProcessOrders(new[] { new Order("ORD-001", 29.99m), new Order("ORD-002", 49.99m) });
 

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -60,6 +60,7 @@ public static class IEnumerableExtensions
     /// <returns>
     /// true if the source sequence contains no elements; otherwise, false.
     /// </returns>
+    /// <exception cref="ArgumentNullException">source is null.</exception>
     /// <example>
     /// <code>
     /// var items = new List&lt;string&gt;();


### PR DESCRIPTION
## Summary
Two small fixes that together unblock the open analyzer-bump PRs (#83 Meziantou, #84 SonarAnalyzer) and resolve the failing build on \`main\`.

### 1. RCS1140 in \`IEnumerableExtensions.cs:73\`
\`IsEmpty<T>\` throws \`ArgumentNullException\` but the XML doc lacked the \`<exception>\` tag. Added it, matching the pattern used by every other throwing method in this file (\`ForEach\`, \`None\`, \`Do\`, \`Shuffle\`).

### 2. MA0003 in \`examples/IsNullOrEmpty.Example/Program.cs:23\`
A latent error that was masked by RCS1140 stopping the build first. Changed \`ProcessOrders(null)\` → \`ProcessOrders(orders: null)\` to make the literal-null argument explicit.

## Test plan
- [x] \`dotnet build --configuration Release\` — 0 warnings, 0 errors
- [x] \`dotnet test --configuration Release\` — 45/45 passing on every TFM (net5.0–net10.0, net462–net481)
- [ ] CI passes on this PR
- [ ] Once merged, dependabot PRs #83 and #84 should pass on rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)