### PR TITLE
Expand benchmark coverage to ForEach, IsEmpty, None, Do

### DIFF
--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/DoBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/DoBenchmarks.cs
@@ -32,16 +32,18 @@ public class DoBenchmarks
     }
 
     [Benchmark]
-    public void Do_Iterator()
+    public long Do_Iterator()
     {
         long sum = 0;
         _data.Do(x => sum += x).Consume(_consumer);
+        return sum;
     }
 
     [Benchmark]
-    public void Linq_Select_SideEffect()
+    public long Linq_Select_SideEffect()
     {
         long sum = 0;
         _data.Select(x => { sum += x; return x; }).Consume(_consumer);
+        return sum;
     }
 }

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/DoBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/DoBenchmarks.cs
@@ -1,0 +1,47 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+
+namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
+
+/// <summary>
+/// Measures the overhead of <c>Do</c> (side-effect iterator) compared to
+/// <c>Select</c> with a side-effecting selector and a raw foreach.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class DoBenchmarks
+{
+    private readonly Consumer _consumer = new();
+    private int[] _data = null!;
+
+    [Params(100, 10_000, 1_000_000)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _data = Enumerable.Range(0, Size).ToArray();
+
+    [Benchmark(Baseline = true)]
+    public long Foreach_RawLoop()
+    {
+        long sum = 0;
+        foreach (var x in _data)
+        {
+            sum += x;
+        }
+        return sum;
+    }
+
+    [Benchmark]
+    public void Do_Iterator()
+    {
+        long sum = 0;
+        _data.Do(x => sum += x).Consume(_consumer);
+    }
+
+    [Benchmark]
+    public void Linq_Select_SideEffect()
+    {
+        long sum = 0;
+        _data.Select(x => { sum += x; return x; }).Consume(_consumer);
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
@@ -38,9 +38,9 @@ public class ForEachBenchmarks
         return sum;
     }
 
-    // Calls bind through IEnumerable<int> so the extension method
-    // (and its List<T> fast-path dispatch) is actually invoked, rather
-    // than the BCL List<T>.ForEach instance method.
+    // The following benchmarks bind the call through IEnumerable<int> so
+    // the extension method (and its List<T> fast-path dispatch) is actually
+    // invoked, rather than the BCL List<T>.ForEach instance method.
 
     [Benchmark]
     public long Extension_OnListAsEnumerable()

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
@@ -12,6 +12,8 @@ public class ForEachBenchmarks
 {
     private List<int> _list = null!;
     private int[] _array = null!;
+    private IEnumerable<int> _listAsEnumerable = null!;
+    private IEnumerable<int> _arrayAsEnumerable = null!;
     private IEnumerable<int> _yieldEnumerable = null!;
 
     [Params(100, 10_000, 1_000_000)]
@@ -22,6 +24,8 @@ public class ForEachBenchmarks
     {
         _list = Enumerable.Range(0, Size).ToList();
         _array = _list.ToArray();
+        _listAsEnumerable = _list;
+        _arrayAsEnumerable = _array;
         _yieldEnumerable = YieldRange(Size);
     }
 
@@ -36,19 +40,23 @@ public class ForEachBenchmarks
         return sum;
     }
 
+    // Calls bind through IEnumerable<int> so the extension method
+    // (and its List<T> fast-path dispatch) is actually invoked, rather
+    // than the BCL List<T>.ForEach instance method.
+
     [Benchmark]
-    public long Extension_OnList()
+    public long Extension_OnListAsEnumerable()
     {
         long sum = 0;
-        _list.ForEach(i => sum += i);
+        _listAsEnumerable.ForEach(i => sum += i);
         return sum;
     }
 
     [Benchmark]
-    public long Extension_OnArray()
+    public long Extension_OnArrayAsEnumerable()
     {
         long sum = 0;
-        _array.ForEach(i => sum += i);
+        _arrayAsEnumerable.ForEach(i => sum += i);
         return sum;
     }
 
@@ -57,6 +65,14 @@ public class ForEachBenchmarks
     {
         long sum = 0;
         _yieldEnumerable.ForEach(i => sum += i);
+        return sum;
+    }
+
+    [Benchmark]
+    public long Bcl_ListForEach()
+    {
+        long sum = 0;
+        _list.ForEach(i => sum += i);
         return sum;
     }
 

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
@@ -1,0 +1,70 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
+
+/// <summary>
+/// Compares the IEnumerable{T}.ForEach extension against the BCL List{T}.ForEach
+/// fast path (which the extension dispatches to) and a hand-written foreach loop.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class ForEachBenchmarks
+{
+    private List<int> _list = null!;
+    private int[] _array = null!;
+    private IEnumerable<int> _yieldEnumerable = null!;
+
+    [Params(100, 10_000, 1_000_000)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _list = Enumerable.Range(0, Size).ToList();
+        _array = _list.ToArray();
+        _yieldEnumerable = YieldRange(Size);
+    }
+
+    [Benchmark(Baseline = true)]
+    public long Foreach_RawLoop()
+    {
+        long sum = 0;
+        foreach (var item in _list)
+        {
+            sum += item;
+        }
+        return sum;
+    }
+
+    [Benchmark]
+    public long Extension_OnList()
+    {
+        long sum = 0;
+        _list.ForEach(i => sum += i);
+        return sum;
+    }
+
+    [Benchmark]
+    public long Extension_OnArray()
+    {
+        long sum = 0;
+        _array.ForEach(i => sum += i);
+        return sum;
+    }
+
+    [Benchmark]
+    public long Extension_OnYieldEnumerable()
+    {
+        long sum = 0;
+        _yieldEnumerable.ForEach(i => sum += i);
+        return sum;
+    }
+
+    private static IEnumerable<int> YieldRange(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
@@ -11,7 +11,6 @@ namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
 public class ForEachBenchmarks
 {
     private List<int> _list = null!;
-    private int[] _array = null!;
     private IEnumerable<int> _listAsEnumerable = null!;
     private IEnumerable<int> _arrayAsEnumerable = null!;
     private IEnumerable<int> _yieldEnumerable = null!;
@@ -23,9 +22,8 @@ public class ForEachBenchmarks
     public void Setup()
     {
         _list = Enumerable.Range(0, Size).ToList();
-        _array = _list.ToArray();
         _listAsEnumerable = _list;
-        _arrayAsEnumerable = _array;
+        _arrayAsEnumerable = _list.ToArray();
         _yieldEnumerable = YieldRange(Size);
     }
 

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsEmptyBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsEmptyBenchmarks.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
+
+/// <summary>
+/// Compares IsEmpty / IsNullOrEmpty / None against the canonical LINQ
+/// <c>!source.Any()</c> idiom. Highlights the ICollection{T} fast path.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class IsEmptyBenchmarks
+{
+    private List<int> _emptyList = null!;
+    private List<int> _populatedList = null!;
+    private IEnumerable<int> _emptyYield = null!;
+    private IEnumerable<int> _populatedYield = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _emptyList = new List<int>();
+        _populatedList = Enumerable.Range(0, 1000).ToList();
+        _emptyYield = YieldRange(0);
+        _populatedYield = YieldRange(1000);
+    }
+
+    // ----- Empty ICollection -----
+
+    [Benchmark(Baseline = true)]
+    public bool Linq_NotAny_EmptyList() => !_emptyList.Any();
+
+    [Benchmark]
+    public bool IsEmpty_EmptyList() => _emptyList.IsEmpty();
+
+    [Benchmark]
+    public bool IsNullOrEmpty_EmptyList() => _emptyList.IsNullOrEmpty();
+
+    [Benchmark]
+    public bool None_EmptyList() => _emptyList.None();
+
+    // ----- Populated ICollection -----
+
+    [Benchmark]
+    public bool Linq_NotAny_PopulatedList() => !_populatedList.Any();
+
+    [Benchmark]
+    public bool IsEmpty_PopulatedList() => _populatedList.IsEmpty();
+
+    [Benchmark]
+    public bool None_PopulatedList() => _populatedList.None();
+
+    // ----- Yield enumerables (no ICollection fast path) -----
+
+    [Benchmark]
+    public bool IsEmpty_EmptyYield() => _emptyYield.IsEmpty();
+
+    [Benchmark]
+    public bool IsEmpty_PopulatedYield() => _populatedYield.IsEmpty();
+
+    private static IEnumerable<int> YieldRange(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsEmptyBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsEmptyBenchmarks.cs
@@ -4,7 +4,8 @@ namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
 
 /// <summary>
 /// Compares IsEmpty / IsNullOrEmpty / None against the canonical LINQ
-/// <c>!source.Any()</c> idiom. Highlights the ICollection{T} fast path.
+/// <c>!source.Any()</c> idiom. Highlights the <see cref="ICollection{T}"/>
+/// fast path.
 /// </summary>
 [MemoryDiagnoser]
 [RankColumn]

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsEmptyBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsEmptyBenchmarks.cs
@@ -52,10 +52,28 @@ public class IsEmptyBenchmarks
     // ----- Yield enumerables (no ICollection fast path) -----
 
     [Benchmark]
+    public bool Linq_NotAny_EmptyYield() => !_emptyYield.Any();
+
+    [Benchmark]
     public bool IsEmpty_EmptyYield() => _emptyYield.IsEmpty();
 
     [Benchmark]
+    public bool IsNullOrEmpty_EmptyYield() => _emptyYield.IsNullOrEmpty();
+
+    [Benchmark]
+    public bool None_EmptyYield() => _emptyYield.None();
+
+    [Benchmark]
+    public bool Linq_NotAny_PopulatedYield() => !_populatedYield.Any();
+
+    [Benchmark]
     public bool IsEmpty_PopulatedYield() => _populatedYield.IsEmpty();
+
+    [Benchmark]
+    public bool IsNullOrEmpty_PopulatedYield() => _populatedYield.IsNullOrEmpty();
+
+    [Benchmark]
+    public bool None_PopulatedYield() => _populatedYield.None();
 
     private static IEnumerable<int> YieldRange(int count)
     {

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/NonePredicateBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/NonePredicateBenchmarks.cs
@@ -18,7 +18,7 @@ public class NonePredicateBenchmarks
     [GlobalSetup]
     public void Setup() => _data = Enumerable.Range(0, Size).ToArray();
 
-    // Predicate that fails near the end (worst case for short-circuit)
+    // Predicate that matches near the end (near worst case for short-circuit)
     [Benchmark(Baseline = true)]
     public bool Linq_NotAny_LateMatch() => !_data.Any(x => x == Size - 1);
 

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/NonePredicateBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/NonePredicateBenchmarks.cs
@@ -4,7 +4,8 @@ namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
 
 /// <summary>
 /// Compares <c>None(predicate)</c> against the canonical <c>!source.Any(predicate)</c>
-/// idiom. Should be a wash since None just delegates to !Any.
+/// idiom. Results are expected to be close, since None forwards to !Any after
+/// performing argument validation.
 /// </summary>
 [MemoryDiagnoser]
 [RankColumn]

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/NonePredicateBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/NonePredicateBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
+
+/// <summary>
+/// Compares <c>None(predicate)</c> against the canonical <c>!source.Any(predicate)</c>
+/// idiom. Should be a wash since None just delegates to !Any.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class NonePredicateBenchmarks
+{
+    private int[] _data = null!;
+
+    [Params(100, 10_000, 1_000_000)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _data = Enumerable.Range(0, Size).ToArray();
+
+    // Predicate that fails near the end (worst case for short-circuit)
+    [Benchmark(Baseline = true)]
+    public bool Linq_NotAny_LateMatch() => !_data.Any(x => x == Size - 1);
+
+    [Benchmark]
+    public bool None_LateMatch() => _data.None(x => x == Size - 1);
+
+    // Predicate that never matches (full traversal)
+    [Benchmark]
+    public bool Linq_NotAny_NoMatch() => !_data.Any(x => x < 0);
+
+    [Benchmark]
+    public bool None_NoMatch() => _data.None(x => x < 0);
+}

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Program.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Running;
-using Wolfgang.Extensions.IEnumerable.Benchmarks;
 
-BenchmarkRunner.Run<ShuffleBenchmarks>();
+BenchmarkSwitcher
+    .FromAssembly(typeof(Program).Assembly)
+    .Run(args);


### PR DESCRIPTION
## Summary
The benchmarks project previously covered only `Shuffle`. Adds four benchmark classes exercising the rest of the public extension surface and pinning the LINQ baselines they should beat (or match).

- **ForEachBenchmarks** — `List<T>.ForEach` fast path vs `IEnumerable.ForEach` fallback vs raw `foreach`, across 100 / 10k / 1M items
- **IsEmptyBenchmarks** — `IsEmpty` / `IsNullOrEmpty` / `None` vs `!source.Any()`, both `ICollection<T>` fast path and yield enumerables
- **NonePredicateBenchmarks** — `None(predicate)` vs `!source.Any(predicate)`, late-match and no-match
- **DoBenchmarks** — `Do` iterator vs `Select` side-effect vs raw `foreach`

Each class uses `[MemoryDiagnoser] + [RankColumn]` to match the existing `ShuffleBenchmarks`. No production code changes.

## Test plan
- [x] `dotnet build -c Release` clean (0 warnings, 0 errors)
- [x] BDN smoke run discovers and executes new benchmarks
- [ ] Spot-run individual benchmarks locally before relying on results

🤖 Generated with [Claude Code](https://claude.com/claude-code)