### PR TITLE
chore: bump version to 1.2.1

### DIFF
--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -3,7 +3,7 @@
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
 		<Title>$(AssemblyName)</Title>
 		<Authors>Chris Wolfgang</Authors>
 		<Description>A collection of extension methods for types that implement IEnumerable</Description>


### PR DESCRIPTION
## Summary
Bumps `<Version>` from 1.2.0 to 1.2.1.

## What's in v1.2.1
PATCH release — documentation + analyzer maintenance, no public API changes:

- Document `ArgumentNullException` on `IsEmpty<T>` and use named arg in the XML doc example
- Centralize analyzer PackageReferences in `Directory.Build.props`
- Bump `Meziantou.Analyzer` 3.0.50 → 3.0.77 (two Dependabot bumps)

## After merge
Create the GitHub Release at `v1.2.1` to trigger NuGet publish via `release.yaml`.