### PR TITLE
fix(docfx): swap return values for fewer-prerelease-id case (descending order)

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -170,8 +170,13 @@ jobs:
             $maxLen = [Math]::Max($aIds.Length, $bIds.Length)
 
             for ($i = 0; $i -lt $maxLen; $i++) {
-              if ($i -ge $aIds.Length) { return -1 } # a has fewer identifiers -> lower precedence
-              if ($i -ge $bIds.Length) { return 1 }  # b has fewer identifiers -> lower precedence
+              # SemVer §11.4.4: fewer prerelease identifiers = lower precedence.
+              # In *descending* order (newest first), the lower-precedence
+              # value sorts AFTER the higher-precedence one, so the comparator
+              # must return positive when 'a' is the shorter (lower-precedence)
+              # one and negative when 'b' is.
+              if ($i -ge $aIds.Length) { return 1 }  # a has fewer identifiers -> lower precedence -> sorts later
+              if ($i -ge $bIds.Length) { return -1 } # b has fewer identifiers -> lower precedence -> sorts later
 
               $aId = $aIds[$i]
               $bId = $bIds[$i]


### PR DESCRIPTION
## Summary
Mirrors [repo-template#341](https://github.com/Chris-Wolfgang/repo-template/pull/341). Fixes the SemVer prerelease comparator in `docfx.yaml` so descending version order is correct when prereleases differ in identifier count.

## Detail
The version-tag sorter that builds `versions.json` was returning the wrong sign for the "fewer prerelease identifiers" case:

```powershell
for ($i = 0; $i -lt $maxLen; $i++) {
  if ($i -ge $aIds.Length) { return -1 } # a has fewer identifiers -> lower precedence
  if ($i -ge $bIds.Length) { return 1 }  # b has fewer identifiers -> lower precedence
  ...
}
```

Per SemVer §11.4.4, fewer prerelease identifiers = lower precedence (`1.0.0-alpha` < `1.0.0-alpha.1`). For descending order (newest first), the lower-precedence value sorts AFTER the higher-precedence one — so the comparator must return **positive** when `a` is the shorter (lower-precedence) one. The in-code comments correctly identified the precedence relationship; only the return values were inverted.

## Concrete impact

| Before (wrong) | After (correct) |
|---|---|
| `1.0.0-alpha` | `1.0.0-alpha.1` |
| `1.0.0-alpha.1` | `1.0.0-alpha` |

Visible only when the project ships multiple prereleases of the same base version with differing identifier counts. IEnumerable doesn't currently have such combinations, so no live `versions.json` is misordered today — but the fix prevents silent issues if/when prereleases get longer suffixes.

## Why
Caught by Copilot on PR #95 (the docfx-bootstrap PR that synced this code in). Fix lands here directly rather than waiting for a template-sync wave so IEnumerable doesn't carry the bug between now and the next sync.

## Out of scope
Copilot also flagged a cleanup-push-before-deploy split (the gh-pages cleanup commit pushes its own commit, then the deploy step pushes another, leaving a partial-cleanup window if deploy fails). Real concern but requires a bigger refactor (combining cleanup and deploy into a single worktree). Separate PR worth its own review.

## Note about the protected-files guard
This PR touches `.github/workflows/docfx.yaml` so the `Detect .NET Projects` guard will fail it. Maintainer override required — same path as the other workflow-touching PRs.

## Test plan
- [ ] Maintainer override + merge
- [ ] Either order with repo-template#341 is fine; both end up with the same fix