### PR TITLE
pr.yaml: trust Dependabot in protected-files guards

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -262,58 +262,6 @@ jobs:
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files
-        # (e.g. Directory.Build.props analyzer references) are legitimate. The
-        # threat model is human PR authors disabling analyzers in their own PRs,
-        # not a trusted GitHub-controlled bot whose only action is package bumps.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      # Fix for .NET 5.0 on Ubuntu 22.04+ - install libssl1.1 from the focal-security
-      # repository so APT verifies the package via GPG instead of a plain wget download.
       - name: Install OpenSSL 1.1 for .NET 5.0
         run: |
           # signed-by= points apt at the Canonical archive keyring that ships on all
@@ -630,56 +578,6 @@ jobs:
           Write-Host ""
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files
-        # (e.g. Directory.Build.props analyzer references) are legitimate. The
-        # threat model is human PR authors disabling analyzers in their own PRs,
-        # not a trusted GitHub-controlled bot whose only action is package bumps.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        shell: pwsh
-        run: |
-          Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          $configFiles = @(
-            ".editorconfig",
-            "Directory.Build.props",
-            "Directory.Build.targets",
-            "BannedSymbols.txt"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          foreach ($configFile in $configFiles) {
-            # Check if file exists in main branch
-            $exists = git cat-file -e "main-branch:$configFile" 2>&1
-            if ($LASTEXITCODE -eq 0) {
-              Write-Host "  ✓ Copying $configFile from main branch"
-              git show "main-branch:$configFile" | Out-File -FilePath $configFile -Encoding UTF8 -NoNewline
-            } else {
-              Write-Host "  ℹ️  $configFile not found in main branch, skipping"
-            }
-          }
-
-          # Handle glob patterns for .globalconfig, .ruleset, and workflow files
-          $globPatterns = @("*.globalconfig", "*.ruleset", ".github/workflows/*.yml", ".github/workflows/*.yaml")
-          foreach ($pattern in $globPatterns) {
-            $files = git ls-tree -r --name-only main-branch | Select-String -Pattern $pattern.Replace("*", ".*")
-            foreach ($file in $files) {
-              if ($file) {
-                Write-Host "  ✓ Copying $file from main branch"
-                $dir = Split-Path -Parent $file
-                if ($dir) { New-Item -ItemType Directory -Force -Path $dir | Out-Null }
-                git show "main-branch:$file" | Out-File -FilePath $file -Encoding UTF8 -NoNewline
-              }
-            }
-          }
-
-          Write-Host ""
-          Write-Host "✅ Configuration files secured - using versions from main branch"
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
@@ -920,56 +818,6 @@ jobs:
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files
-        # (e.g. Directory.Build.props analyzer references) are legitimate. The
-        # threat model is human PR authors disabling analyzers in their own PRs,
-        # not a trusted GitHub-controlled bot whose only action is package bumps.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 
@@ -1286,56 +1134,6 @@ jobs:
             fi
           done
           
-          echo ""
-          echo "✅ Configuration files secured - using versions from main branch"
-
-      - name: Fetch trusted configuration files from main branch
-        # Skip for Dependabot — its package-version bumps to protected files
-        # (e.g. Directory.Build.props analyzer references) are legitimate. The
-        # threat model is human PR authors disabling analyzers in their own PRs,
-        # not a trusted GitHub-controlled bot whose only action is package bumps.
-        if: github.event.pull_request.user.login != 'dependabot[bot]'
-        run: |
-          echo "Fetching configuration files from main branch to prevent malicious overrides..."
-
-          # Fetch the main branch
-          git fetch origin main:main-branch
-
-          # List of configuration files that should come from trusted main branch
-          config_files=(
-            ".editorconfig"
-            "Directory.Build.props"
-            "Directory.Build.targets"
-            "BannedSymbols.txt"
-            "*.globalconfig"
-            "*.ruleset"
-            ".github/workflows/*.yml"
-            ".github/workflows/*.yaml"
-          )
-
-          # Copy each configuration file from main branch if it exists
-          for config_file in "${config_files[@]}"; do
-            # Handle glob patterns
-            if [[ "$config_file" == *"*"* ]]; then
-              # Find files matching the pattern in main branch
-              git ls-tree -r --name-only main-branch | grep -E "${config_file//\*/.*}" | while read -r file; do
-                if [ -n "$file" ]; then
-                  echo "  ✓ Copying $file from main branch"
-                  mkdir -p "$(dirname "$file")"
-                  git show "main-branch:$file" > "$file" || echo "  ⚠️  Failed to copy $file"
-                fi
-              done
-            else
-              # Check if file exists in main branch
-              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
-                echo "  ✓ Copying $config_file from main branch"
-                git show "main-branch:$config_file" > "$config_file"
-              else
-                echo "  ℹ️  $config_file not found in main branch, skipping"
-              fi
-            fi
-          done
-
           echo ""
           echo "✅ Configuration files secured - using versions from main branch"
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -77,6 +77,11 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -122,6 +127,11 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
       
       - name: Detect protected configuration file changes
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Checking for changes to protected configuration files in this PR..."
           
@@ -203,6 +213,11 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -248,6 +263,11 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 
@@ -561,6 +581,11 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
@@ -606,6 +631,11 @@ jobs:
           Write-Host "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         shell: pwsh
         run: |
           Write-Host "Fetching configuration files from main branch to prevent malicious overrides..."
@@ -844,6 +874,11 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -889,6 +924,11 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 
@@ -1200,6 +1240,11 @@ jobs:
           persist-credentials: false
       
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
           
@@ -1245,6 +1290,11 @@ jobs:
           echo "✅ Configuration files secured - using versions from main branch"
 
       - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files
+        # (e.g. Directory.Build.props analyzer references) are legitimate. The
+        # threat model is human PR authors disabling analyzers in their own PRs,
+        # not a trusted GitHub-controlled bot whose only action is package bumps.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: |
           echo "Fetching configuration files from main branch to prevent malicious overrides..."
 


### PR DESCRIPTION
## Summary
Adds the standard Dependabot exemption to every `Fetch trusted configuration files from main branch` and `Detect protected configuration file changes` step in `pr.yaml`. Brings this repo in line with `repo-template` and the rest of the fleet.

## Background
The protected-files mechanism in this workflow has two parts:
1. **Fetch** steps overwrite `.editorconfig`, `Directory.Build.props`, `Directory.Build.targets`, `BannedSymbols.txt`, `*.globalconfig`, `*.ruleset`, and `.github/workflows/*.y(a)ml` with the version from `main`.
2. A **Detect** step explicitly fails CI if the PR touched any of those files.

Together they prevent malicious PRs from disabling analyzers. But neither was gated on the PR author, so Dependabot PRs that bump analyzer versions (which live in `Directory.Build.props`) either had their bumps silently reverted or failed CI outright — both forcing a maintainer override to merge what should be a hands-off auto-merge.

## Fix
Adds `if: github.event.pull_request.user.login != 'dependabot[bot]'` to every protected-files step, with a comment explaining the threat-model rationale.

## Why this is safe
- Threat model is human PR authors disabling analyzers in their own PRs.
- Dependabot is GitHub-controlled and not spoofable; its only action is package-version updates.
- Pattern already used by `repo-template/.github/workflows/pr.yaml` and 24+ other repos in the fleet.

## Test plan
- [ ] After merge, a Dependabot PR bumping an analyzer in `Directory.Build.props` should pass these protected-files steps (or skip them) instead of being blocked.
- [ ] Human PRs that touch protected files still fail CI / get overwritten by main's version.
