### PR TITLE
feature/A: Tier-1 polish — CHANGELOG seed, copilot-instructions, slnx hygiene

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,162 +1,32 @@
-# Copilot Coding Agent Instructions
+# Copilot Instructions for Wolfgang.Extensions.IEnumerable
 
-## Repository Summary
+## Project Overview
+- **Package:** Wolfgang.Extensions.IEnumerable
+- **Namespace:** Wolfgang.Extensions.IEnumerable
+- **Purpose:** Extension methods for `System.Collections.Generic.IEnumerable<T>` — emptiness checks, iteration, and shuffling
 
-This is a **repository template** for creating new .NET repositories. It provides a standardized structure with comprehensive GitHub integration, CI/CD workflows, and development tooling. The template is designed for .NET 8.0 projects using C# and follows Microsoft's recommended project organization patterns.
+## Key Types
+- `IEnumerableExtensions` — static class with extension methods on `IEnumerable<T>`
 
-**Repository Type**: Template (not a working project)  
-**Target Platform**: .NET 8.0  
-**Primary Language**: C#  
-**Size**: Small template (~15 configuration files, empty project folders)  
+## Extension Methods
+- `ForEach(Action<T>)` — eagerly invokes an action for each item (void return)
+- `Do(Action<T>)` — lazy variant of `ForEach` that yields each item after invoking the action (returns `IEnumerable<T>`)
+- `IsEmpty()` — true when the sequence contains no elements
+- `IsNullOrEmpty()` — true when the sequence is null OR contains no elements
+- `None()` — inverse of `Any()` (no predicate)
+- `None(Func<T, bool> predicate)` — true when no element matches the predicate
+- `Shuffle()` — returns a new sequence in random order using Fisher-Yates with a thread-safe RNG
 
-## Build and Validation Instructions
+## Important Notes
+- `ForEach` / `IsEmpty` / `IsNullOrEmpty` / `None` accept `null` sources (treated as empty / no-op)
+- `Shuffle` requires a non-null source and materializes the input before shuffling
+- Public API is tracked by `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` when the analyzer baseline is activated — additions surface as RS0016 at compile time
 
-### Prerequisites
-- .NET 8.0.x SDK (always install if not present)
-- ReportGenerator tool (installed via `dotnet tool install -g dotnet-reportgenerator-globaltool`)
-- DevSkim CLI (installed via `dotnet tool install --global Microsoft.CST.DevSkim.CLI`)
+## Code Style
+- Allman brace style
+- 3 blank lines between members
+- File-scoped namespaces
+- Warnings as errors in Release builds
 
-### Build Process (For Repositories Created from This Template)
-**IMPORTANT**: This template has no buildable projects. These commands apply to repositories created FROM this template.
-
-1. **Restore Dependencies** (always run first):
-   ```bash
-   dotnet restore
-   ```
-
-2. **Build Solution**:
-   ```bash
-   dotnet build --no-restore --configuration Release
-   ```
-
-3. **Run Tests with Coverage**:
-   ```bash
-   # Find and test all test projects
-   find ./tests -type f -name '*Test*.csproj' | while read proj; do
-     dotnet test "$proj" --no-build --configuration Release --collect:"XPlat Code Coverage" --results-directory "./TestResults"
-   done
-   ```
-
-4. **Generate Coverage Reports**:
-   ```bash
-   reportgenerator -reports:"TestResults/**/coverage.cobertura.xml" -targetdir:"CoverageReport" -reporttypes:"Html;TextSummary;MarkdownSummaryGithub;CsvSummary"
-   ```
-
-5. **Security Scanning**:
-   ```bash
-   devskim analyze --source-code . -f text --output-file devskim-results.txt -E
-   ```
-
-### Critical Build Requirements
-- **Code Coverage**: Minimum 80% line coverage required for all projects
-- **Security Scanning**: DevSkim must pass with no errors
-- **Build Configuration**: Always use Release configuration for CI
-- **Test Pattern**: Test projects must match `*Test*.csproj` pattern in `/tests` folder
-
-### Common Issues and Workarounds
-- **Timeout Issues**: Coverage and security scans can take 5-10 minutes for larger projects
-- **Coverage Threshold Failures**: If below 80%, the build will fail - this is by design
-- **Missing Test Projects**: The workflow expects at least one test project in `/tests` folder
-- **DevSkim False Positives**: Review `devskim-results.txt` for any security findings
-
-## Project Layout and Architecture
-
-### Standard Directory Structure
-```
-root/
-├── MySolution.sln              # Solution file (create in root)
-├── src/                        # Application projects
-│   ├── MyApp/
-│   │   └── MyApp.csproj
-│   └── MyLib/
-│       └── MyLib.csproj
-├── tests/                      # Test projects (required)
-│   ├── MyApp.Tests/
-│   │   └── MyApp.Tests.csproj
-│   └── MyLib.Tests/
-│       └── MyLib.Tests.csproj
-├── benchmarks/                 # Performance benchmarks (optional)
-│   └── MyApp.Benchmarks/
-│       └── MyApp.Benchmarks.csproj
-├── examples/                   # Example projects (optional)
-├── docs/                       # Documentation
-└── .github/                    # GitHub configuration
-```
-
-### Key Configuration Files
-- **`.editorconfig`**: Code style rules (C# file-scoped namespaces, var preferences, analyzer severity)
-- **`.gitignore`**: Comprehensive .NET gitignore (Visual Studio, build artifacts, packages)
-- **`SETUP.md`**: Detailed repository setup instructions (delete after setup)
-- **`CONTRIBUTING.md`**: Empty - populate with contribution guidelines
-- **`CODE_OF_CONDUCT.md`**: Standard Contributor Covenant v2.0
-
-### GitHub Integration
-- **Workflows**: `.github/workflows/pr.yaml` - Comprehensive CI/CD pipeline
-- **Issue Templates**: Bug reports (YAML) and feature requests (Markdown)
-- **PR Template**: Structured pull request template with checklists
-- **CODEOWNERS**: Default owner `@Chris-Wolfgang`, update usernames as needed
-- **Dependabot**: Configured for NuGet packages in all project directories
-
-### Continuous Integration Pipeline (`.github/workflows/pr.yaml`)
-The workflow runs on pull requests to `main` branch and includes:
-
-1. **Environment**: Ubuntu Latest with .NET 8.0.x
-2. **Build Steps**: Checkout → Setup .NET → Restore → Build → Test → Coverage → Security
-3. **Artifacts**: Coverage reports and DevSkim results uploaded
-4. **Branch Protection**: Configured to require this workflow to pass before merging
-
-**Security Note**: Workflow includes safeguard `if: github.repository != 'Chris-Wolfgang/repo-template'` to prevent running on the template itself.
-
-### Branch Protection Configuration
-When using this template, configure these settings in GitHub (detailed in `SETUP.md`):
-- Require status checks to pass before merging
-- Require branches to be up to date
-- Require pull request reviews (including Copilot reviews)
-- Restrict deletions and block force pushes
-- Require code scanning
-
-## Key Files and Locations
-
-### Root Directory Files
-- `README.md` - Basic template description (update for your project)
-- `LICENSE` - Mozilla Public License 2.0
-- `SETUP.md` - Template setup instructions (delete after setup)
-- `.editorconfig` - Code style configuration
-- `.gitignore` - .NET-specific gitignore
-
-### GitHub Directory (`.github/`)
-- `workflows/pr.yaml` - Main CI/CD pipeline
-- `ISSUE_TEMPLATE/` - Bug report (YAML) and feature request templates
-- `pull_request_template.md` - PR template with checklists
-- `CODEOWNERS` - Code ownership rules
-- `dependabot.yml` - Dependency update configuration
-
-### Project Directories (Currently Empty in Template)
-- `src/` - Application source code
-- `tests/` - Unit and integration tests
-- `benchmarks/` - Performance benchmarks
-- `examples/` - Example usage projects
-- `docs/` - Documentation (contains placeholder `index.html`)
-
-## Agent Guidelines
-
-### Trust These Instructions
-This information has been validated against the template structure and GitHub workflows. **Only search for additional information if these instructions are incomplete or found to be incorrect.**
-
-### When Working with This Template
-1. **Creating New Projects**: Follow the structure outlined in `SETUP.md`
-2. **Adding Dependencies**: Use `dotnet add package` commands
-3. **Code Style**: Follow `.editorconfig` rules (file-scoped namespaces, explicit typing)
-4. **Testing**: Ensure test projects follow `*Test*.csproj` naming convention
-5. **Coverage**: Aim for >80% code coverage to pass CI
-6. **Security**: Review DevSkim findings and address security concerns
-
-### Validation Steps
-Before submitting changes:
-1. Run `dotnet restore && dotnet build --configuration Release`
-2. Run tests with coverage collection
-3. Verify coverage meets 80% threshold
-4. Run DevSkim security scan
-5. Ensure all GitHub Actions checks pass
-
-This template provides a solid foundation for .NET projects with enterprise-grade CI/CD, security scanning, and development best practices built-in.
+## Target Frameworks
+- net462, netstandard2.0, net8.0, net10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [1.2.0] - 2026-04-27
+
+### Added
+
+- `Do()` extension method as an alias / mirror of `ForEach()` to match
+  the naming used in `IAsyncEnumerable-Extensions`, plus example
+  project demonstrating side-effect usage.
+
+### Changed
+
+- Analyzer `PackageReference`s moved from `Directory.Build.props` into
+  individual csproj files for this release (later reverted to
+  `Directory.Build.props` as the canonical template-sync settled on
+  fleet-wide source of truth).
+- Bumped SonarAnalyzer.CSharp from 10.21.0 to 10.24.0; Meziantou.Analyzer
+  from 3.0.27 to 3.0.50; coverlet.collector from 8.0.1 to 10.0.0;
+  Microsoft.NET.Test.Sdk from 17.11.1 to 17.13.0.
+- Upgraded `pr.yaml` to v3 (Gated) multi-stage workflow.
+
+### Removed
+
+- Stale `.github/workflows/create-labels.yaml` (replaced by
+  `Setup-Labels.ps1` script run once at repo bootstrap).
+
+### Fixed
+
+- `None()` no longer duplicates `IsEmpty()` implementation (S4144).
+- 18 analyzer violations in tests and examples (MA0047/MA0048/S3903
+  and related).
+- Documentation, test coverage, and code quality issues across the
+  test suite.
+
+## [1.1.0] - 2026-03-24
+
+### Added
+
+- `Do()` extension method (initial introduction with examples and
+  documentation updates).
+
+## [1.0.0] - 2026-01-19
+
+### Added
+
+- Initial stable release with `ForEach`, `None`, `IsEmpty`,
+  `IsNullOrEmpty`, and `Shuffle` extension methods on
+  `System.Collections.Generic.IEnumerable<T>`.
+- Fisher-Yates `Shuffle` implementation with thread-safe RNG.
+- Application and NuGet package icons.
+
+[Unreleased]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/releases/tag/v1.0.0

--- a/IEnumerable-Extensions.slnx
+++ b/IEnumerable-Extensions.slnx
@@ -1,12 +1,15 @@
 <Solution>
   <Folder Name="/.root/">
     <File Path=".editorconfig" />
+    <File Path=".gitattributes" />
     <File Path=".gitignore" />
+    <File Path="CHANGELOG.md" />
     <File Path="CODE_OF_CONDUCT.md" />
     <File Path="CONTRIBUTING.md" />
+    <File Path="Directory.Build.props" />
     <File Path="LICENSE" />
     <File Path="README.md" />
-    <File Path="SETUP.md" />
+    <File Path="SECURITY.md" />
   </Folder>
   <Folder Name="/.root/.github/">
     <File Path=".github/CODEOWNERS" />
@@ -15,21 +18,25 @@
     <File Path=".github/pull_request_template.md" />
   </Folder>
   <Folder Name="/.root/.github/workflows/">
-    <File Path=".github/workflows/create-labels.yaml" />
+    <File Path=".github/workflows/benchmarks.yaml" />
+    <File Path=".github/workflows/build-all-versions.yaml" />
+    <File Path=".github/workflows/codeql.yaml" />
     <File Path=".github/workflows/docfx.yaml" />
     <File Path=".github/workflows/pr.yaml" />
     <File Path=".github/workflows/release.yaml" />
+    <File Path=".github/workflows/stryker.yaml" />
   </Folder>
   <Folder Name="/.root/ISSUE_TEMPLATE/">
     <File Path=".github/ISSUE_TEMPLATE/BUG_REPORT.yaml" />
-    <File Path=".github/ISSUE_TEMPLATE/feature_request.md" />
+    <File Path=".github/ISSUE_TEMPLATE/feature_request.yaml" />
+    <File Path=".github/ISSUE_TEMPLATE/maintenance-task.yaml" />
   </Folder>
   <Folder Name="/benchmark/">
     <Project Path="benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/examples/">
-    <Project Path="examples/ForEach.Example/ForEach.Example.csproj" />
     <Project Path="examples/Do.Example/Do.Example.csproj" />
+    <Project Path="examples/ForEach.Example/ForEach.Example.csproj" />
     <Project Path="examples/IsEmpty.Example/IsEmpty.Example.csproj" />
     <Project Path="examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj" />
     <Project Path="examples/None.Example/None.Example.csproj" />


### PR DESCRIPTION
## Summary

Stacked on `canonical-unprotected` as part of the per-repo release pilot
(`main ← canonical-protected ← vNext ← canonical-unprotected ← feature/A ← feature/B`).

- **CHANGELOG.md (D2)** — seeded with v1.0.0 / v1.1.0 / v1.2.0 entries from
  git tag history with Keep-a-Changelog formatting and compare-link footer.
- **`.github/copilot-instructions.md`** — replaced the generic repo-template
  scaffolding (161 lines, "Repository Type: Template (not a working project)")
  with IEnumerable-specific guidance: extension method list, null-handling
  notes, public-API-analyzer hook, code style + TFM reference.
- **`IEnumerable-Extensions.slnx`** — drop stale `create-labels.yaml` ref;
  add new template-tracked workflows (benchmarks, build-all-versions, codeql,
  stryker); add `CHANGELOG.md` / `.gitattributes` / `Directory.Build.props` /
  `SECURITY.md` to `/.root/`; add `maintenance-task.yaml` to ISSUE_TEMPLATE;
  rename `feature_request.md` → `.yaml` to match repo state.

## Test plan

- [x] `dotnet build -c Release` — 0 warnings, 0 errors
- [ ] CI green on PR