### PR TITLE
feature/C: fix doc claims about null-source acceptance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,10 @@
 - `Shuffle()` — returns a new sequence in random order using Fisher-Yates with a thread-safe RNG
 
 ## Important Notes
-- `ForEach` / `IsEmpty` / `IsNullOrEmpty` / `None` accept `null` sources (treated as empty / no-op)
-- `Shuffle` requires a non-null source and materializes the input before shuffling
+- All methods **except `IsNullOrEmpty`** throw `ArgumentNullException` when `source` is null. Only `IsNullOrEmpty` returns `true` for a null source.
+- `None`, `Do`, `ForEach`, `Shuffle` also throw `ArgumentNullException` when their `action` / `predicate` argument is null.
+- `Shuffle` materializes the input to a `List<T>` before shuffling.
+- `ForEach` has a fast path for `List<T>` (delegates to `List<T>.ForEach`); `IsEmpty` / `IsNullOrEmpty` have a fast path for `ICollection<T>` (uses `Count` without enumerating).
 - Public API is tracked by `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` when the analyzer baseline is activated — additions surface as RS0016 at compile time
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var doubled = items
     .ToList();
 
 items.IsEmpty();                                  // false
-((int[]?)null).IsNullOrEmpty();                   // true
+((int[]?)null).IsNullOrEmpty();                   // true (only IsNullOrEmpty accepts null)
 items.None(x => x > 10);                          // true
 items.None();                                     // false (has items)
 
@@ -62,8 +62,9 @@ var shuffled = items.Shuffle().ToList();          // random order (Fisher-Yates)
 ```
 
 All methods are pure with respect to the input sequence: they do not mutate
-the source. `ForEach` / `IsEmpty` / `IsNullOrEmpty` / `None` accept `null`
-sources (treated as empty / no-op). `Shuffle` requires a non-null source.
+the source. Only `IsNullOrEmpty` accepts a null source (returns `true`); every
+other method throws `ArgumentNullException` when `source` is null. Methods
+that take an `action` / `predicate` also throw on a null callback.
 
 ---
 
@@ -72,7 +73,7 @@ sources (treated as empty / no-op). `Shuffle` requires a non-null source.
 ### Methods
 | Method | Description |
 |--------|-------------|
-| `ForEach(Action<T>)` | Eagerly invokes an action for each item. Null source is a no-op. |
+| `ForEach(Action<T>)` | Eagerly invokes an action for each item. Throws `ArgumentNullException` if `source` or `action` is null. |
 | `Do(Action<T>)` | Lazy variant of `ForEach` — yields each item after invoking the action. |
 | `IsEmpty()` | Returns `true` when the sequence contains no elements. |
 | `IsNullOrEmpty()` | Returns `true` when the sequence is `null` OR contains no elements. |
@@ -95,8 +96,8 @@ var pipeline = new[] { 1, 2, 3 }
 
 // Emptiness
 new int[0].IsEmpty();                                // true
-((IEnumerable<int>?)null).IsNullOrEmpty();           // true
-((IEnumerable<int>?)null).IsEmpty();                 // true (null treated as empty)
+((IEnumerable<int>?)null).IsNullOrEmpty();           // true (null-tolerant)
+// ((IEnumerable<int>?)null).IsEmpty();              // throws ArgumentNullException
 
 // None
 new[] { 1, 2, 3 }.None();                            // false


### PR DESCRIPTION
## Summary

Stacked on `feature/B-readme-polish` (#146). Fixes a docs bug introduced by
feature/A + feature/B in this same chain.

**The bug:** copilot-instructions and README both told readers that
`ForEach` / `IsEmpty` / `None` accept null sources ("treated as empty /
no-op"). The source code throws `ArgumentNullException` for all methods
except `IsNullOrEmpty`.

**The fix:** rewrite the null-handling prose in both files to enumerate
which methods throw on null `source` / `action` / `predicate`, fix the
methods-table description for `ForEach`, and replace the misleading
`((IEnumerable<int>?)null).IsEmpty()` example with a "// throws" comment.

Surfaced by code-review issue #112. The remaining code-review findings
(signature inconsistency — only `Shuffle` drops the `?`; `None(source)`
skipping the explicit null check before delegating to `IsEmpty`) are
deferred for a behaviour-change PR after release, since touching the
nullable annotations on the public surface is a contract change.

## Test plan

- [x] Docs-only change — no code modified.
- [ ] CI green.