### PR TITLE
feature/D: fix PackageProjectUrl + add PackageTags (CI1 / #131)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,10 @@
 - `Shuffle()` — returns a new sequence in random order using Fisher-Yates with a thread-safe RNG
 
 ## Important Notes
-- `ForEach` / `IsEmpty` / `IsNullOrEmpty` / `None` accept `null` sources (treated as empty / no-op)
-- `Shuffle` requires a non-null source and materializes the input before shuffling
+- All methods **except `IsNullOrEmpty`** throw `ArgumentNullException` when `source` is null. Only `IsNullOrEmpty` returns `true` for a null source.
+- `None`, `Do`, `ForEach`, `Shuffle` also throw `ArgumentNullException` when their `action` / `predicate` argument is null.
+- `Shuffle` materializes the input to a `List<T>` before shuffling.
+- `ForEach` has a fast path for `List<T>` (delegates to `List<T>.ForEach`); `IsEmpty` / `IsNullOrEmpty` have a fast path for `ICollection<T>` (uses `Count` without enumerating).
 - Public API is tracked by `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` when the analyzer baseline is activated — additions surface as RS0016 at compile time
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var doubled = items
     .ToList();
 
 items.IsEmpty();                                  // false
-((int[]?)null).IsNullOrEmpty();                   // true
+((int[]?)null).IsNullOrEmpty();                   // true (only IsNullOrEmpty accepts null)
 items.None(x => x > 10);                          // true
 items.None();                                     // false (has items)
 
@@ -62,8 +62,9 @@ var shuffled = items.Shuffle().ToList();          // random order (Fisher-Yates)
 ```
 
 All methods are pure with respect to the input sequence: they do not mutate
-the source. `ForEach` / `IsEmpty` / `IsNullOrEmpty` / `None` accept `null`
-sources (treated as empty / no-op). `Shuffle` requires a non-null source.
+the source. Only `IsNullOrEmpty` accepts a null source (returns `true`); every
+other method throws `ArgumentNullException` when `source` is null. Methods
+that take an `action` / `predicate` also throw on a null callback.
 
 ---
 
@@ -72,7 +73,7 @@ sources (treated as empty / no-op). `Shuffle` requires a non-null source.
 ### Methods
 | Method | Description |
 |--------|-------------|
-| `ForEach(Action<T>)` | Eagerly invokes an action for each item. Null source is a no-op. |
+| `ForEach(Action<T>)` | Eagerly invokes an action for each item. Throws `ArgumentNullException` if `source` or `action` is null. |
 | `Do(Action<T>)` | Lazy variant of `ForEach` — yields each item after invoking the action. |
 | `IsEmpty()` | Returns `true` when the sequence contains no elements. |
 | `IsNullOrEmpty()` | Returns `true` when the sequence is `null` OR contains no elements. |
@@ -95,8 +96,8 @@ var pipeline = new[] { 1, 2, 3 }
 
 // Emptiness
 new int[0].IsEmpty();                                // true
-((IEnumerable<int>?)null).IsNullOrEmpty();           // true
-((IEnumerable<int>?)null).IsEmpty();                 // true (null treated as empty)
+((IEnumerable<int>?)null).IsNullOrEmpty();           // true (null-tolerant)
+// ((IEnumerable<int>?)null).IsEmpty();              // throws ArgumentNullException
 
 // None
 new[] { 1, 2, 3 }.None();                            // false

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -5,7 +5,8 @@
 		<Version>1.2.1</Version>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for types that implement IEnumerable</Description>
-		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Wolfgang.Extensions.IEnumerable</PackageProjectUrl>
+		<PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>
+		<PackageProjectUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions.git</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Stacked on `feature/C-docs-null-fix` (#147). Addresses NuGet package
quality (#131) findings surfaced during the per-repo release pilot.

- **PackageProjectUrl** was set to `https://github.com/Chris-Wolfgang/Wolfgang.Extensions.IEnumerable`
  (the package id, not the repo path) — that URL **404s**. Fixed to
  `https://github.com/Chris-Wolfgang/IEnumerable-Extensions`.
- **PackageTags** was missing entirely — added a relevant set
  (`IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp`)
  so the package is discoverable on NuGet's tag search.

## Test plan

- [x] `dotnet pack src/...csproj -c Release` succeeds; .nupkg + .snupkg generated.
- [ ] After merge, verify nuget.org listing shows the corrected project URL on next release.

Closes #131.