### PR TITLE
feature/E: fix flaky and vacuous Shuffle tests (#143)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,8 +18,10 @@
 - `Shuffle()` — returns a new sequence in random order using Fisher-Yates with a thread-safe RNG
 
 ## Important Notes
-- `ForEach` / `IsEmpty` / `IsNullOrEmpty` / `None` accept `null` sources (treated as empty / no-op)
-- `Shuffle` requires a non-null source and materializes the input before shuffling
+- All methods **except `IsNullOrEmpty`** throw `ArgumentNullException` when `source` is null. Only `IsNullOrEmpty` returns `true` for a null source.
+- `None`, `Do`, `ForEach`, `Shuffle` also throw `ArgumentNullException` when their `action` / `predicate` argument is null.
+- `Shuffle` materializes the input to a `List<T>` before shuffling.
+- `ForEach` has a fast path for `List<T>` (delegates to `List<T>.ForEach`); `IsEmpty` / `IsNullOrEmpty` have a fast path for `ICollection<T>` (uses `Count` without enumerating).
 - Public API is tracked by `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt` when the analyzer baseline is activated — additions surface as RS0016 at compile time
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var doubled = items
     .ToList();
 
 items.IsEmpty();                                  // false
-((int[]?)null).IsNullOrEmpty();                   // true
+((int[]?)null).IsNullOrEmpty();                   // true (only IsNullOrEmpty accepts null)
 items.None(x => x > 10);                          // true
 items.None();                                     // false (has items)
 
@@ -62,8 +62,9 @@ var shuffled = items.Shuffle().ToList();          // random order (Fisher-Yates)
 ```
 
 All methods are pure with respect to the input sequence: they do not mutate
-the source. `ForEach` / `IsEmpty` / `IsNullOrEmpty` / `None` accept `null`
-sources (treated as empty / no-op). `Shuffle` requires a non-null source.
+the source. Only `IsNullOrEmpty` accepts a null source (returns `true`); every
+other method throws `ArgumentNullException` when `source` is null. Methods
+that take an `action` / `predicate` also throw on a null callback.
 
 ---
 
@@ -72,7 +73,7 @@ sources (treated as empty / no-op). `Shuffle` requires a non-null source.
 ### Methods
 | Method | Description |
 |--------|-------------|
-| `ForEach(Action<T>)` | Eagerly invokes an action for each item. Null source is a no-op. |
+| `ForEach(Action<T>)` | Eagerly invokes an action for each item. Throws `ArgumentNullException` if `source` or `action` is null. |
 | `Do(Action<T>)` | Lazy variant of `ForEach` — yields each item after invoking the action. |
 | `IsEmpty()` | Returns `true` when the sequence contains no elements. |
 | `IsNullOrEmpty()` | Returns `true` when the sequence is `null` OR contains no elements. |
@@ -95,8 +96,8 @@ var pipeline = new[] { 1, 2, 3 }
 
 // Emptiness
 new int[0].IsEmpty();                                // true
-((IEnumerable<int>?)null).IsNullOrEmpty();           // true
-((IEnumerable<int>?)null).IsEmpty();                 // true (null treated as empty)
+((IEnumerable<int>?)null).IsNullOrEmpty();           // true (null-tolerant)
+// ((IEnumerable<int>?)null).IsEmpty();              // throws ArgumentNullException
 
 // None
 new[] { 1, 2, 3 }.None();                            // false

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -5,7 +5,8 @@
 		<Version>1.2.1</Version>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for types that implement IEnumerable</Description>
-		<PackageProjectUrl>https://github.com/Chris-Wolfgang/Wolfgang.Extensions.IEnumerable</PackageProjectUrl>
+		<PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>
+		<PackageProjectUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions.git</RepositoryUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
@@ -17,29 +17,46 @@ public class ShuffleTests
 
 
     [Fact]
-    public void Shuffle_returns_original_items_in_random_order()
+    public void Shuffle_returns_a_permutation_of_the_input_with_the_same_multiset_of_elements()
     {
+        // Multiset equality — every input element appears exactly once in the output,
+        // and the output has the same length. No order assertion (would be flaky:
+        // 1/N! chance of returning the original order, non-zero on small N).
         var source = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
         var actualResult = source.ToEnumerable().Shuffle().ToArray();
 
-        Assert.NotEqual(source, actualResult);
         Assert.Equal(source.Length, actualResult.Length);
-
-        foreach (var number in source)
-        {
-            Assert.Contains(number, actualResult);
-        }
+        Assert.Equal(source.OrderBy(x => x), actualResult.OrderBy(x => x));
     }
 
 
+
     [Fact]
-    public void Shuffle_does_not_change_the_order_of_the_original_list()
+    public void Shuffle_with_large_input_moves_at_least_one_element_from_its_original_index()
     {
-        var source = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+        // Statistical "did anything actually shuffle?" check on a 100-element input.
+        // Probability all 100 elements stay in place = 1/100! ≈ 10^-158 — effectively
+        // zero. False-negative rate is far below any CI flakiness budget.
+        var source = Enumerable.Range(0, 100).ToArray();
+
+        var actualResult = source.ToEnumerable().Shuffle().ToArray();
+
+        var movedCount = source.Where((value, index) => actualResult[index] != value).Count();
+        Assert.True(movedCount > 0, "Expected Shuffle to move at least one element from its original index.");
+    }
+
+
+
+    [Fact]
+    public void Shuffle_does_not_mutate_the_input_list_in_place()
+    {
+        // Pass a real List<T> (not a wrapped iterator) so that an in-place
+        // Fisher-Yates implementation that forgets to copy would be observable.
+        var source = new List<int> { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
         var expectedResult = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-        source.ToEnumerable().Shuffle();
+        source.Shuffle().ToArray();
 
         Assert.Equal(expectedResult, source);
     }
@@ -51,7 +68,7 @@ public class ShuffleTests
     {
         var source = Array.Empty<int>();
 
-        var result = source.ToEnumerable().Shuffle();
+        var result = source.Shuffle();
 
         Assert.Empty(result);
     }
@@ -63,7 +80,7 @@ public class ShuffleTests
     {
         var source = new[] { 42 };
 
-        var result = source.ToEnumerable().Shuffle().ToArray();
+        var result = source.Shuffle().ToArray();
 
         Assert.Single(result);
         Assert.Equal(42, result[0]);


### PR DESCRIPTION
## Summary

Stacked on `feature/D-csproj-metadata` (#148). Addresses two must-fix /
should-fix findings from the test-quality audit posted on #143:

1. **`Shuffle_returns_original_items_in_random_order`** asserted
   `Assert.NotEqual(source, actualResult)` against a 10-element input.
   Fisher-Yates can legitimately return the original order with probability
   1/10! ≈ 1-in-3.6M. Replaced with **multiset equality** (`OrderBy ==
   OrderBy`) which proves the output is a permutation of the input without
   any randomness assertion.

2. Added a new statistical test `Shuffle_with_large_input_moves_at_least_one_element_from_its_original_index`
   that shuffles 100 elements and asserts at least one moved. False-negative
   rate is 1/100! ≈ 10^-158 — effectively zero. This catches a no-op Shuffle
   implementation that the multiset check alone wouldn't.

3. **`Shuffle_does_not_change_the_order_of_the_original_list`** asserted
   `Assert.Equal(expectedResult, source)` where both were independent arrays
   of the same values — trivially true regardless of Shuffle's behavior.
   Replaced with `Shuffle_does_not_mutate_the_input_list_in_place` that
   passes a real `List<int>` so an in-place Fisher-Yates that forgot to copy
   would actually be observable.

4. Dropped unnecessary `.ToEnumerable()` wrapping on empty / single-element
   cases — Shuffle has no fast path, so the wrapper achieves nothing.

## Test plan

- [x] `dotnet test --framework net10.0 --filter "FullyQualifiedName~ShuffleTests"` → 6/6 pass.
- [ ] CI green on all TFMs.

Partial progress on #143 (T4 test-quality audit). Remaining findings from
the audit comment (verbose names that could collapse via `[Theory]`,
`Balloon` test data hoisting) are deferred — they're nits, not bugs.