### PR TITLE
feature/F: address remaining Copilot review nits on #145 / #146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0] - 2026-04-27
 
-### Added
-
-- `Do()` extension method — a lazy passthrough side-effect operator
-  (returns `IEnumerable<T>`, yielding each item after invoking the
-  action), complementing the existing eager void-returning `ForEach()`.
-  Naming matches `IAsyncEnumerable-Extensions`. Includes an example
-  project demonstrating side-effect usage.
-
 ### Changed
 
 - Analyzer `PackageReference`s moved from `Directory.Build.props` into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Do()` extension method as an alias / mirror of `ForEach()` to match
-  the naming used in `IAsyncEnumerable-Extensions`, plus example
+- `Do()` extension method — a lazy passthrough side-effect operator
+  (returns `IEnumerable<T>`, yielding each item after invoking the
+  action), complementing the existing eager void-returning `ForEach()`.
+  Naming matches `IAsyncEnumerable-Extensions`. Includes an example
   project demonstrating side-effect usage.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wolfgang.Extensions.IEnumerable
 
-A collection of extension methods for `IEnumerable<T>` in .Net
+A collection of extension methods for `IEnumerable<T>` in .NET.
 
 [![NuGet](https://img.shields.io/nuget/v/Wolfgang.Extensions.IEnumerable.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Extensions.IEnumerable)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Extensions.IEnumerable.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Extensions.IEnumerable)
@@ -61,8 +61,9 @@ items.None();                                     // false (has items)
 var shuffled = items.Shuffle().ToList();          // random order (Fisher-Yates)
 ```
 
-All methods are pure with respect to the input sequence: they do not mutate
-the source. Only `IsNullOrEmpty` accepts a null source (returns `true`); every
+None of these methods mutate the source sequence — `ForEach` and `Do` invoke
+your `Action<T>` for its side effects but never modify the upstream items
+themselves. Only `IsNullOrEmpty` accepts a null source (returns `true`); every
 other method throws `ArgumentNullException` when `source` is null. Methods
 that take an `action` / `predicate` also throw on a null callback.
 


### PR DESCRIPTION
## Summary

Stacked on `feature/E-shuffle-test-fixes` (#149). Sweeps up the Copilot
review nits on the earlier #145 and #146 PRs that PR #147 didn't already
fix:

- **README.md:3** — ".Net" → ".NET" (Microsoft branding) and add trailing period.
- **README.md:64** — replace "All methods are pure" (inaccurate because
  `ForEach` and `Do` are explicitly side-effecting) with a more precise
  "none of these methods mutate the source sequence" + clarification that
  the action callback's side effects are intentional.
- **CHANGELOG.md:28** — the seeded 1.2.0 entry called `Do()` an "alias /
  mirror of `ForEach()`" but `Do` is a lazy `IEnumerable<T>`-returning
  passthrough while `ForEach` is an eager `void` terminal operation.
  Rewrote the bullet to make the distinction clear.

The earlier Copilot comments about null-source acceptance and the
`((IEnumerable<int>?)null).IsEmpty()` example were already addressed in
PR #147. The `||` markdown table comment was on a transient diff state —
no `||` rows exist in the current README.

## Test plan

- [x] Docs-only — no code changes.
- [ ] Render preview confirms badges still resolve and table renders correctly.