### PR TITLE
feature/G: PublicApiAnalyzers baseline (#130 / A1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0] - 2026-04-27
 
-### Added
-
-- `Do()` extension method — a lazy passthrough side-effect operator
-  (returns `IEnumerable<T>`, yielding each item after invoking the
-  action), complementing the existing eager void-returning `ForEach()`.
-  Naming matches `IAsyncEnumerable-Extensions`. Includes an example
-  project demonstrating side-effect usage.
-
 ### Changed
 
 - Analyzer `PackageReference`s moved from `Directory.Build.props` into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Do()` extension method as an alias / mirror of `ForEach()` to match
-  the naming used in `IAsyncEnumerable-Extensions`, plus example
+- `Do()` extension method — a lazy passthrough side-effect operator
+  (returns `IEnumerable<T>`, yielding each item after invoking the
+  action), complementing the existing eager void-returning `ForEach()`.
+  Naming matches `IAsyncEnumerable-Extensions`. Includes an example
   project demonstrating side-effect usage.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wolfgang.Extensions.IEnumerable
 
-A collection of extension methods for `IEnumerable<T>` in .Net
+A collection of extension methods for `IEnumerable<T>` in .NET.
 
 [![NuGet](https://img.shields.io/nuget/v/Wolfgang.Extensions.IEnumerable.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Extensions.IEnumerable)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Extensions.IEnumerable.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Extensions.IEnumerable)
@@ -61,8 +61,9 @@ items.None();                                     // false (has items)
 var shuffled = items.Shuffle().ToList();          // random order (Fisher-Yates)
 ```
 
-All methods are pure with respect to the input sequence: they do not mutate
-the source. Only `IsNullOrEmpty` accepts a null source (returns `true`); every
+None of these methods mutate the source sequence — `ForEach` and `Do` invoke
+your `Action<T>` for its side effects but never modify the upstream items
+themselves. Only `IsNullOrEmpty` accepts a null source (returns `true`); every
 other method throws `ArgumentNullException` when `source` is null. Methods
 that take an `action` / `predicate` also throw on a null callback.
 

--- a/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Shipped.txt
@@ -1,0 +1,9 @@
+#nullable enable
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Do<T>(this System.Collections.Generic.IEnumerable<T>? source, System.Action<T>! action) -> System.Collections.Generic.IEnumerable<T>!
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ForEach<T>(this System.Collections.Generic.IEnumerable<T>? source, System.Action<T>! action) -> void
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.IsEmpty<T>(this System.Collections.Generic.IEnumerable<T>? source) -> bool
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.IsNullOrEmpty<T>(this System.Collections.Generic.IEnumerable<T>? source) -> bool
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.None<T>(this System.Collections.Generic.IEnumerable<T>? source) -> bool
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.None<T>(this System.Collections.Generic.IEnumerable<T>? source, System.Func<T, bool>! predicate) -> bool
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+Wolfgang.Extensions.IEnumerable.IEnumerableExtensions

--- a/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary

Stacked on `feature/F-copilot-review-nits` (#150). Activates the
PublicApiAnalyzers (A1) baseline for this repo — landing the per-repo
work that the plan called for at "release prep time" but which the IDE
codefix wasn't required to produce for IEnumerable's flat 7-method
surface.

**What changes**
- Added `src/Wolfgang.Extensions.IEnumerable/PublicAPI.Shipped.txt`
  capturing the v1.2.0 public surface (8 entries: the static class
  + 7 extension methods Do / ForEach / IsEmpty / IsNullOrEmpty /
  None (2 overloads) / Shuffle).
- Added empty `PublicAPI.Unshipped.txt` (just the `#nullable enable`
  header) — future API additions surface here at compile time as RS0016
  until promoted to Shipped.

**How the analyzer activates**
`Directory.Build.props` already includes both files conditionally:
```xml
<AdditionalFiles Include="PublicAPI.Shipped.txt" Condition="Exists('PublicAPI.Shipped.txt')" />
<AdditionalFiles Include="PublicAPI.Unshipped.txt" Condition="Exists('PublicAPI.Unshipped.txt')" />
```
Creating the files flips the analyzer from disabled (its 3.3.4 default
when files are absent) to active for this project only — no csproj edit
needed.

**What this buys**
- API additions surface as **RS0016** ("not part of declared public API")
- API removals surface as **RS0017** ("declared public API missing
  matching symbol")
- Both errors under `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
  in Release builds → breaking-change review gate at PR time.

## Test plan

- [x] `dotnet build src/Wolfgang.Extensions.IEnumerable -c Release -p:WarningsAsErrors=RS0016`
      → Build succeeded. 0 Warning(s) 0 Error(s) on all 4 TFMs.
- [x] Full solution Release build still 0/0.
- [ ] CI green on PR.

Closes #130.