### PR TITLE
feature/H: restore <AssemblyVersion> pinned to MAJOR.0.0.0

### DIFF
--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -9,7 +9,7 @@
 		     InformationalVersion (the latter auto-derived from <Version>) carry
 		     the actual release version. -->
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
+		<FileVersion>$(Version).0</FileVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for types that implement IEnumerable</Description>
 		<PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -3,6 +3,13 @@
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Version>1.2.1</Version>
+		<!-- Pin AssemblyVersion to MAJOR.0.0.0 so .NET Framework consumers
+		     don't need a binding redirect on every minor/patch bump. Only
+		     change this on a deliberate breaking API change (i.e., MAJOR
+		     bump per SemVer). FileVersion + InformationalVersion (the latter
+		     auto-derived from <Version>) carry the actual release version. -->
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>$(Version).0</FileVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for types that implement IEnumerable</Description>
 		<PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -3,13 +3,13 @@
 		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Version>1.2.1</Version>
-		<!-- Pin AssemblyVersion to MAJOR.0.0.0 so .NET Framework consumers
-		     don't need a binding redirect on every minor/patch bump. Only
-		     change this on a deliberate breaking API change (i.e., MAJOR
-		     bump per SemVer). FileVersion + InformationalVersion (the latter
-		     auto-derived from <Version>) carry the actual release version. -->
+		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+		     do not need to recompile / add binding redirects on every minor/patch
+		     bump. Bump only on a deliberate breaking API change. FileVersion +
+		     InformationalVersion (the latter auto-derived from <Version>) carry
+		     the actual release version. -->
 		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>$(Version).0</FileVersion>
+		<FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
 		<Title>$(AssemblyName)</Title>
 		<Description>A collection of extension methods for types that implement IEnumerable</Description>
 		<PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>


### PR DESCRIPTION
## Summary

Stacked on `feature/G-publicapi-baseline` (#151). Reverses the C4 effect
of dropping `<AssemblyVersion>` from the src csproj — the original C4
rationale ("stale relative to released package versions") was the wrong
frame for a library that ships a `net462` TFM.

## Why this matters

`AssemblyVersion` is the **binding identity** the CLR uses to resolve
references. On .NET Framework, changing it between releases means every
consumer needs a binding redirect in `app.config` / `web.config`:

```xml
<bindingRedirect oldVersion="1.0.0.0-1.2.1.0" newVersion="1.2.1.0"/>
```

Without one, the runtime throws `FileLoadException: Could not load file
or assembly 'Wolfgang.Extensions.IEnumerable, Version=1.2.1.0, ...'`.

The standard library convention (NodaTime, Newtonsoft.Json, AutoMapper):

| Property | Bumps on | v1.2.1 value |
|---|---|---|
| `AssemblyVersion` | **MAJOR only** | `1.0.0.0` |
| `AssemblyFileVersion` | every release | `1.2.1.0` |
| `Version` (NuGet) | every release | `1.2.1` |

The originally-hardcoded `1.0.0` `AssemblyVersion` was correct, not stale.

## Verified

Built `src/Wolfgang.Extensions.IEnumerable/` Release for net10.0 and
inspected the generated `AssemblyInfo.cs`:

```
[assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]
[assembly: System.Reflection.AssemblyFileVersionAttribute("1.2.1.0")]
[assembly: System.Reflection.AssemblyInformationalVersionAttribute("1.2.1+19c608e...")]
```

## Going forward

`AssemblyVersion` bumps to `2.0.0.0` **only** on a deliberate breaking
API change. RS0017 from the PublicApiAnalyzers (added in #151) will
surface any candidate breaking changes at PR-time.

## Blast radius beyond this repo

- **DateTime-Extensions** already released v1.3.0 with the dropped
  `AssemblyVersion` — tracking a v1.3.1 patch separately.
- **22 other repos** received the C4 fanout — tracking issues will be
  filed against each so the restoration ships in their first vNext
  release cycle.

## Test plan

- [x] `dotnet build` Release net10.0 → 0/0, AssemblyVersion = 1.0.0.0 confirmed.
- [ ] CI green across all 4 TFMs on PR.