### PR TITLE
Adopt canonical redirect-style docs landing page

### DIFF
--- a/.github/version-picker-template.html
+++ b/.github/version-picker-template.html
@@ -4,6 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{TITLE}}</title>
+
+  <!-- Auto-redirect to the latest version of the docs.
+       The in-page version picker (docfx_project/public/version-picker.js)
+       lets readers switch versions from any page once they land there, so
+       the root no longer needs to be a "pick a version" landing page —
+       a redirect to /versions/latest/ is the desired UX.
+
+       meta-refresh works without JavaScript; the JS fallback below kicks
+       in if the meta-refresh is blocked by some agent. Visible text +
+       <noscript> link covers everything else. -->
+  <meta http-equiv="refresh" content="0; url=versions/latest/">
+  <link rel="canonical" href="versions/latest/">
+
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -12,28 +25,34 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      justify-content: center;
       padding: 3rem 1rem;
       min-height: 100vh;
       margin: 0;
+      text-align: center;
     }
-    h1 { font-size: 2rem; margin-bottom: 0.5rem; color: #cba6f7; }
-    p  { color: #a6adc8; margin-bottom: 2rem; }
-    ul { list-style: none; padding: 0; width: 100%; max-width: 480px; }
-    li a {
-      display: block; padding: 0.75rem 1.25rem; margin-bottom: 0.5rem;
-      border-radius: 6px; background: #313244; color: #89b4fa;
-      text-decoration: none; font-size: 1.05rem; transition: background 0.15s;
-    }
-    li a:hover { background: #45475a; }
-    li.latest a { background: #1e66f5; color: #fff; font-weight: bold; }
-    li.latest a:hover { background: #1959d9; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; color: #cba6f7; }
+    a  { color: #89b4fa; }
   </style>
+  <script>
+    // Backup redirect in case meta-refresh is suppressed.
+    setTimeout(function () {
+      window.location.replace('versions/latest/');
+    }, 50);
+  </script>
 </head>
 <body>
   <h1>{{TITLE}}</h1>
-  <p>Select a documentation version:</p>
-  <ul>
-{{VERSION_LIST}}
-  </ul>
+  <p>Redirecting to the <a href="versions/latest/">latest documentation</a>&hellip;</p>
+  <noscript>
+    <p>JavaScript is disabled. <a href="versions/latest/">Click here</a> to continue.</p>
+  </noscript>
+  <!-- The docfx.yaml workflow's substitution still looks for {{VERSION_LIST}}
+       but the placeholder is intentionally omitted from this template: a
+       missing pattern is a true no-op for PowerShell's `-replace` (returns
+       the original string unchanged). The in-page <select> dropdown shipped
+       in docfx_project/public/version-picker.js is now the canonical
+       version-selector UI, so no list of links needs to be rendered into
+       the root redirect page. -->
 </body>
 </html>


### PR DESCRIPTION
## Summary

Replace `.github/version-picker-template.html` with the canonical
version used in DateTime-Extensions (verbatim).

The current landing page (the big "Select a documentation version"
button list) is the pre-D8 design. The canonical pattern is now:

- Root `index.html` = tiny meta-refresh that bounces to `/versions/latest/`
- In-page `<select>` dropdown (from `docfx_project/public/version-picker.js`)
  is the version-selector UI on every docs page

`version-picker.js` is already identical to DateTime-Extensions; only the
template was stale.

## Effect after merge

Re-running `build-all-versions.yaml` (or `docfx.yaml`) will regenerate
the root `index.html` from the new template.

## Test plan

- [ ] CI green
- [ ] After merge: run `build-all-versions.yaml`
- [ ] Confirm `https://chris-wolfgang.github.io/IEnumerable-Extensions/`
      auto-redirects to `/versions/latest/`
- [ ] Confirm the navbar `<select>` picker appears on the loaded docs page