### PR TITLE
CR: sync README + docs/ + CONTRIBUTING with v1.3.0 public surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -430,4 +430,5 @@ nuget-packages/
 # DocFX generated files
 docfx_project/_site/
 docfx_project/obj/
+docfx_project/api/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ You can contribute in several ways:
 
 This project maintains **extremely high code quality standards** through multiple layers of static analysis and automated enforcement.
 
-### The 7 Analyzers
+### The 8 Analyzers
 
 All code is analyzed by these tools during build:
 
@@ -87,7 +87,20 @@ All code is analyzed by these tools during build:
    - Security vulnerability detection
    - Code smell identification
 
+8. **Microsoft.CodeAnalysis.PublicApiAnalyzers**
+   - Tracks the public API surface via `PublicAPI.Shipped.txt` / `PublicAPI.Unshipped.txt`
+   - Surfaces breaking changes (RS0016/RS0017) at compile time
+   - Activates per project when the Shipped/Unshipped files exist alongside the csproj
+
 ### Async-First Enforcement
+
+> **Note for this library.** Wolfgang.Extensions.IEnumerable is a purely
+> synchronous `IEnumerable<T>` extensions library — none of its public
+> methods are `async`. The rules below describe the analyzer baseline
+> that would catch async regressions if an async method were ever added.
+> Contributors adding new sync extension methods do not need to introduce
+> `async` / `await` / `CancellationToken` parameters.
+
 
 This library **prohibits synchronous blocking calls** via `BannedSymbols.txt`. The following APIs are **banned**:
 
@@ -217,8 +230,7 @@ View the complete configuration in [.editorconfig](.editorconfig).
 - Add relevant tests for new features or bug fixes.
 - Document any public APIs with XML documentation comments.
 - Ensure all analyzer warnings are addressed (they're treated as errors in Release builds).
-- Use async/await patterns - no blocking calls allowed.
-- Include `CancellationToken` parameters in async methods where appropriate.
+- The library is currently synchronous; new async methods (if any) must use async/await, avoid blocking calls, and include `CancellationToken` parameters where appropriate.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ that take an `action` / `predicate` also throw on a null callback.
 | `IsNullOrEmpty()` | Returns `true` when the sequence is `null` OR contains no elements. |
 | `None()` | Inverse of `Any()` — `true` when the sequence has no elements. |
 | `None(Func<T, bool> predicate)` | `true` when no element matches the predicate. |
-| `Shuffle()` | Returns a new sequence in random order (Fisher-Yates + thread-safe RNG). |
+| `Shuffle()` | Returns a new sequence in random order (Fisher-Yates + thread-safe RNG). Eager — the input is fully consumed before the method returns. |
+| `ToEnumerable()` | Wraps the source in a lazy iterator so the returned sequence is guaranteed not to be a more concrete type (`List<T>`, `ICollection<T>`, array). Useful in tests that need to exercise non-`ICollection` code paths. |
 
 ### Examples
 
@@ -106,6 +107,12 @@ new[] { 1, 2, 3 }.None(x => x < 0);                  // true
 
 // Shuffle
 var deck = Enumerable.Range(1, 52).Shuffle().ToList();
+
+// ToEnumerable — strip the concrete type for test fixtures that need to
+// exercise the non-ICollection slow path.
+IEnumerable<int> slowPath = new List<int> { 1, 2, 3 }.ToEnumerable();
+// slowPath is List<int>      // false
+// slowPath is ICollection<int> // false
 ```
 
 ---

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -33,7 +33,10 @@ Safely checks whether a sequence is null or contains no elements in a single ope
 - **None(predicate)**: Determines whether no element of a sequence satisfies a condition (inverse of `Any(predicate)`)
 
 ### Shuffle
-Creates a new `IEnumerable<T>` containing the elements from the source in a random order using the Fisher-Yates shuffle algorithm.
+Creates a new `IEnumerable<T>` containing the elements from the source in a random order using the Fisher-Yates shuffle algorithm. The result is materialized eagerly — the input is fully consumed before `Shuffle` returns.
+
+### ToEnumerable
+Wraps the source in a lazy iterator so that pattern-matching checks (`result is List<T>`, `result is ICollection<T>`, `result is T[]`) return false. Primarily useful in unit tests when you want to exercise the non-`ICollection` slow path of another extension method.
 
 ## Design Philosophy
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -15,10 +15,12 @@ Welcome to the documentation for **Wolfgang.Extensions.IEnumerable**, a comprehe
 Wolfgang.Extensions.IEnumerable provides essential extension methods that complement the standard LINQ operators. The library offers:
 
 ✅ **ForEach** - Execute actions on each element  
+✅ **Do** - Lazy passthrough side-effect action  
 ✅ **IsEmpty** - Check if a sequence is empty  
 ✅ **IsNullOrEmpty** - Safely check for null or empty sequences  
 ✅ **None** - Determine if no elements match criteria  
 ✅ **Shuffle** - Randomize collection order  
+✅ **ToEnumerable** - Strip the concrete type for slow-path testing  
 
 ## Quick Example
 
@@ -95,14 +97,19 @@ Instructions for setting up a development environment to contribute to the libra
 ## Extension Methods Reference
 
 ### ForEach&lt;T&gt;
-**Signature**: `void ForEach<T>(this IEnumerable<T> source, Action<T> action)`
+**Signature**: `void ForEach<T>(this IEnumerable<T>? source, Action<T> action)`
 
-Executes the specified action on each item in the enumerable. Optimized for `List<T>` instances.
+Eagerly executes the specified action on each item in the enumerable. Optimized for `List<T>` instances. Throws `ArgumentNullException` when `source` or `action` is null.
+
+### Do&lt;T&gt;
+**Signature**: `IEnumerable<T> Do<T>(this IEnumerable<T>? source, Action<T> action)`
+
+Lazy variant of `ForEach` — executes the action on each element and yields the element unchanged. Useful for taps in LINQ pipelines (e.g., logging). Throws `ArgumentNullException` when `source` or `action` is null.
 
 ### IsEmpty&lt;T&gt;
-**Signature**: `bool IsEmpty<T>(this IEnumerable<T> source)`
+**Signature**: `bool IsEmpty<T>(this IEnumerable<T>? source)`
 
-Efficiently determines whether a sequence contains no elements. Uses `ICollection<T>.Count` when available.
+Efficiently determines whether a sequence contains no elements. Uses `ICollection<T>.Count` when available. Throws `ArgumentNullException` when `source` is null.
 
 ### IsNullOrEmpty&lt;T&gt;
 **Signature**: `bool IsNullOrEmpty<T>(this IEnumerable<T>? source)`
@@ -111,15 +118,20 @@ Returns true if the source sequence is null or contains no elements. Does not th
 
 ### None&lt;T&gt;
 **Signature**: 
-- `bool None<T>(this IEnumerable<T> source)`
-- `bool None<T>(this IEnumerable<T> source, Func<T, bool> predicate)`
+- `bool None<T>(this IEnumerable<T>? source)`
+- `bool None<T>(this IEnumerable<T>? source, Func<T, bool> predicate)`
 
-Determines whether a sequence contains no elements or no element satisfies a condition. The inverse of `Any()`.
+Determines whether a sequence contains no elements or no element satisfies a condition. The inverse of `Any()`. Throws `ArgumentNullException` when `source` (or `predicate`, for the overload) is null.
 
 ### Shuffle&lt;T&gt;
 **Signature**: `IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)`
 
-Creates a new collection containing elements in random order using the Fisher-Yates shuffle algorithm.
+Creates a new collection containing elements in random order using the Fisher-Yates shuffle algorithm. **Eager** — the entire input is consumed before the method returns. Throws `ArgumentNullException` when `source` is null.
+
+### ToEnumerable&lt;T&gt;
+**Signature**: `IEnumerable<T> ToEnumerable<T>(this IEnumerable<T> source)`
+
+Wraps the source in a lazy iterator so that pattern-matching checks like `result is List<T>` or `result is ICollection<T>` return false. Primarily useful in unit tests for exercising the non-`ICollection` slow path of other extension methods. Throws `ArgumentNullException` when `source` is null.
 
 ## Contributing
 
@@ -138,5 +150,4 @@ This project is licensed under the MIT License. See the [LICENSE](https://github
 ---
 
 **Author**: Chris Wolfgang  
-**Copyright**: © 2026 Chris Wolfgang  
-**Version**: 1.0.0
+**Copyright**: © 2026 Chris Wolfgang


### PR DESCRIPTION
## Summary

Phase 6 doc-file findings from the full code-review pass.

- README.md: add `ToEnumerable` row to the Methods table (added in v1.3.0, previously omitted); add a Shuffle/ToEnumerable example to Quick Start; clarify Shuffle is eager.
- docs/readme.md: add `Do` and `ToEnumerable` to the Overview bullets; add full sections under Extension Methods Reference; fix every signature to use the actual nullable annotation; drop the stale "Version: 1.0.0" footer.
- docs/introduction.md: add a `### ToEnumerable` section; clarify Shuffle is eager.
- CONTRIBUTING.md: "The 7 Analyzers" → "The 8 Analyzers", add the missing PublicApiAnalyzers entry; soften the async-first section for a purely-sync library.
- .gitignore: add `docfx_project/api/` so a local `docfx metadata` run doesn't pollute git status.

This is the first of four stacked PRs from a full code review.

## Test plan

- [ ] CI green (no code changes, build untouched)
- [ ] Re-read every change against the v1.3.0 public surface