### PR TITLE
CR: tidy test csproj + rename a misleading List<T> ForEach test

### DIFF
--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
@@ -48,8 +48,13 @@ public class ForEachTests
 
 
     [Fact]
-    public void ForEach_when_called_on_List_does_not_override_existing_ForEach_on_List()
+    public void ForEach_when_called_on_a_concrete_List_invokes_the_instance_method_not_the_extension()
     {
+        // Documents an intentional non-shadowing property: when `source` is statically
+        // typed as `List<T>`, C# resolves `source.ForEach(...)` to `List<T>.ForEach`
+        // (the BCL instance method) rather than to this library's extension. Our
+        // extension only takes effect when the source is typed as `IEnumerable<T>` —
+        // see the next test for that case.
         var source = new List<int> { 1, 2, 3, 4, 5 };
         var result = new List<int>();
         source.ForEach(i => result.Add(i * 2));

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<Version>1.2.0</Version>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>
@@ -14,8 +13,6 @@
 	<!-- Common packages for all frameworks -->
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.assert" Version="2.9.3" />
-		<PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
 	</ItemGroup>
 
 	<!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
@@ -86,10 +83,15 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<!-- .NET 8.0 - 10.0 specific packages (latest versions) -->
+	<!-- .NET 8.0 - 10.0 specific packages (latest versions).
+	     xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
+	     with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
+	     break the v2 test surface. The other TFM groups above pin
+	     2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
+	     TFM on the v2 runner family. -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'	">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary

Phase 1.7 + 4.5 findings from the code-review pass. **Stacked on top of #164 (docs sync).**

- Test csproj: drop stale `<Version>1.2.0</Version>` (csproj is `IsPackable=false` and src is 1.3.0).
- Test csproj: pin `xunit.runner.visualstudio` to `[2.8.2]` on net8/9/10 to match the v2 xunit surface the rest of the TFM groups use. The previous v3.1.5 pairing violates the CLAUDE.md rule about xunit-v2-with-runner-v3 incompatibility.
- Test csproj: remove redundant direct PackageReferences to `xunit.assert` and `xunit.extensibility.core` (both come in transitively via `xunit`).
- ForEachTests.cs: rename the test that exercises `List<T>.ForEach` (BCL instance method) to make clear that it documents an intentional NON-shadowing property — the previous name implied the extension method was being tested.

## Test plan

- [ ] CI green
- [ ] `dotnet test -c Release -f net10.0` passes 54/54 locally ✓