### PR TITLE
CR: polish source comments + Do iterator pattern + Shuffle/ToEnumerable XML docs

### DIFF
--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -36,8 +36,10 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(action));
         }
 
-        // This block should not be hit as the List<T>.ForEach should get selected by the compiler
-        // but adding it for performance reasons in case it does not
+        // Fast path: when a List<T> reaches this extension via an IEnumerable<T>-typed
+        // call site (where the static binding picks the extension, not List<T>.ForEach),
+        // delegate to the List's instance method. That avoids the IEnumerator<T>
+        // allocation taken by the generic foreach below.
         if (source is List<T> s)
         {
             s.ForEach(action);
@@ -195,28 +197,42 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(action));
         }
 
-        return DoIterator(source, action);
-    }
+        // The actual yielding lives in a static local function so that the
+        // argument-null checks above run EAGERLY at call time. If yield-return
+        // appeared in the outer method body, the whole method would compile
+        // as an iterator and the throws would only fire on first MoveNext —
+        // breaking the "null source/action throws at call site" contract.
+        // Same pattern as ToEnumerable<T> below.
+        return Iterator(source, action);
 
-
-
-    private static IEnumerable<T> DoIterator<T>(IEnumerable<T> source, Action<T> action)
-    {
-        foreach (var item in source)
+        static IEnumerable<T> Iterator(IEnumerable<T> src, Action<T> act)
         {
-            action(item);
-            yield return item;
+            foreach (var item in src)
+            {
+                act(item);
+                yield return item;
+            }
         }
     }
 
 
 
     /// <summary>
-    /// Creates a new IEnumerable{T} containing the elements from source in a random order
+    /// Creates a new sequence containing the elements from <paramref name="source"/>
+    /// in a random order, using a Fisher–Yates shuffle.
     /// </summary>
+    /// <remarks>
+    /// This method is <b>eager</b>: the entire <paramref name="source"/> is consumed
+    /// and the result is materialized before this method returns. The returned
+    /// sequence does NOT preserve deferred-execution semantics — call <c>.Shuffle()</c>
+    /// inside a LINQ pipeline only when that buffering cost is acceptable.
+    /// </remarks>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An IEnumerable{T} whose elements will be randomly ordered.</param>
-    /// <returns>A new IEnumerable{T} containing the elements from source in a random order.</returns>
+    /// <returns>
+    /// A new sequence containing every element of <paramref name="source"/> in a
+    /// random permutation. The input sequence is not mutated.
+    /// </returns>
     /// <exception cref="ArgumentNullException">source is null.</exception>
     /// <example>
     /// <code>
@@ -260,10 +276,13 @@ public static class IEnumerableExtensions
 
     /// <summary>
     /// Wraps an <see cref="IEnumerable{T}"/> in a lazy iterator so the returned
-    /// sequence is guaranteed to NOT be a more concrete type (e.g., <see cref="List{T}"/>,
-    /// <see cref="System.Collections.Generic.ICollection{T}"/>, array). Useful in tests and
-    /// in production code that wants to defeat type-checks for fast paths that
-    /// pattern-match on the runtime type of the source.
+    /// sequence is guaranteed not to be assignable to any more concrete
+    /// enumerable type. Specifically, pattern-matching checks such as
+    /// <c>result is <see cref="List{T}"/></c>,
+    /// <c>result is <see cref="System.Collections.Generic.ICollection{T}"/></c>,
+    /// and <c>result is T[]</c> all return false. Useful in tests (and rarely in
+    /// production code) that want to defeat fast paths which pattern-match on
+    /// the runtime type of the source.
     /// </summary>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IEnumerable{T}"/> to wrap.</param>

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
@@ -48,8 +48,13 @@ public class ForEachTests
 
 
     [Fact]
-    public void ForEach_when_called_on_List_does_not_override_existing_ForEach_on_List()
+    public void ForEach_when_called_on_a_concrete_List_invokes_the_instance_method_not_the_extension()
     {
+        // Documents an intentional non-shadowing property: when `source` is statically
+        // typed as `List<T>`, C# resolves `source.ForEach(...)` to `List<T>.ForEach`
+        // (the BCL instance method) rather than to this library's extension. Our
+        // extension only takes effect when the source is typed as `IEnumerable<T>` —
+        // see the next test for that case.
         var source = new List<int> { 1, 2, 3, 4, 5 };
         var result = new List<int>();
         source.ForEach(i => result.Add(i * 2));

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<Version>1.2.0</Version>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>
@@ -14,8 +13,6 @@
 	<!-- Common packages for all frameworks -->
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.assert" Version="2.9.3" />
-		<PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
 	</ItemGroup>
 
 	<!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
@@ -86,10 +83,15 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<!-- .NET 8.0 - 10.0 specific packages (latest versions) -->
+	<!-- .NET 8.0 - 10.0 specific packages (latest versions).
+	     xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
+	     with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
+	     break the v2 test surface. The other TFM groups above pin
+	     2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
+	     TFM on the v2 runner family. -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'	">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary

Phase 1 + Phase 5 findings. **Stacked on top of #165 (test hygiene).**

- `ForEach` List<T> fast-path comment rewritten — the previous "should not be hit" wording was misleading.
- `Do` refactored to use a static local function iterator (matches the v1.3.0 ToEnumerable<T> pattern adopted in PR #158). Drops the file-private `DoIterator<T>` helper; null-checks still fire eagerly because the outer body has no yield-return.
- `Shuffle` XML doc rewritten with an explicit `<remarks>` noting eager evaluation (the input is fully buffered via `ToList()` before Fisher-Yates runs).
- `ToEnumerable` XML doc tightened — explicit list of pattern-match checks that return false (`List<T>`, `ICollection<T>`, `T[]`).

No public-API change. No behavior change. 54/54 tests pass on net10.0 Release.

## Test plan

- [ ] CI green
- [ ] Coverage holds at 100% line/branch/method on src