### PR TITLE
CR: align Shuffle/ToEnumerable signatures with the rest of the library (IEnumerable<T>?)

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -124,12 +124,12 @@ Returns true if the source sequence is null or contains no elements. Does not th
 Determines whether a sequence contains no elements or no element satisfies a condition. The inverse of `Any()`. Throws `ArgumentNullException` when `source` (or `predicate`, for the overload) is null.
 
 ### Shuffle&lt;T&gt;
-**Signature**: `IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)`
+**Signature**: `IEnumerable<T> Shuffle<T>(this IEnumerable<T>? source)`
 
 Creates a new collection containing elements in random order using the Fisher-Yates shuffle algorithm. **Eager** — the entire input is consumed before the method returns. Throws `ArgumentNullException` when `source` is null.
 
 ### ToEnumerable&lt;T&gt;
-**Signature**: `IEnumerable<T> ToEnumerable<T>(this IEnumerable<T> source)`
+**Signature**: `IEnumerable<T> ToEnumerable<T>(this IEnumerable<T>? source)`
 
 Wraps the source in a lazy iterator so that pattern-matching checks like `result is List<T>` or `result is ICollection<T>` return false. Primarily useful in unit tests for exercising the non-`ICollection` slow path of other extension methods. Throws `ArgumentNullException` when `source` is null.
 

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -240,7 +240,7 @@ public static class IEnumerableExtensions
     /// var shuffled = deck.Shuffle();
     /// </code>
     /// </example>
-    public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
+    public static IEnumerable<T> Shuffle<T>(this IEnumerable<T>? source)
     {
         if (source == null)
         {
@@ -299,7 +299,7 @@ public static class IEnumerableExtensions
     /// // Useful when exercising an extension method's slow path in unit tests.
     /// </code>
     /// </example>
-    public static IEnumerable<T> ToEnumerable<T>(this IEnumerable<T> source)
+    public static IEnumerable<T> ToEnumerable<T>(this IEnumerable<T>? source)
     {
         if (source == null)
         {

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -36,8 +36,10 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(action));
         }
 
-        // This block should not be hit as the List<T>.ForEach should get selected by the compiler
-        // but adding it for performance reasons in case it does not
+        // Fast path: when a List<T> reaches this extension via an IEnumerable<T>-typed
+        // call site (where the static binding picks the extension, not List<T>.ForEach),
+        // delegate to the List's instance method. That avoids the IEnumerator<T>
+        // allocation taken by the generic foreach below.
         if (source is List<T> s)
         {
             s.ForEach(action);
@@ -195,28 +197,42 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(action));
         }
 
-        return DoIterator(source, action);
-    }
+        // The actual yielding lives in a static local function so that the
+        // argument-null checks above run EAGERLY at call time. If yield-return
+        // appeared in the outer method body, the whole method would compile
+        // as an iterator and the throws would only fire on first MoveNext —
+        // breaking the "null source/action throws at call site" contract.
+        // Same pattern as ToEnumerable<T> below.
+        return Iterator(source, action);
 
-
-
-    private static IEnumerable<T> DoIterator<T>(IEnumerable<T> source, Action<T> action)
-    {
-        foreach (var item in source)
+        static IEnumerable<T> Iterator(IEnumerable<T> src, Action<T> act)
         {
-            action(item);
-            yield return item;
+            foreach (var item in src)
+            {
+                act(item);
+                yield return item;
+            }
         }
     }
 
 
 
     /// <summary>
-    /// Creates a new IEnumerable{T} containing the elements from source in a random order
+    /// Creates a new sequence containing the elements from <paramref name="source"/>
+    /// in a random order, using a Fisher–Yates shuffle.
     /// </summary>
+    /// <remarks>
+    /// This method is <b>eager</b>: the entire <paramref name="source"/> is consumed
+    /// and the result is materialized before this method returns. The returned
+    /// sequence does NOT preserve deferred-execution semantics — call <c>.Shuffle()</c>
+    /// inside a LINQ pipeline only when that buffering cost is acceptable.
+    /// </remarks>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An IEnumerable{T} whose elements will be randomly ordered.</param>
-    /// <returns>A new IEnumerable{T} containing the elements from source in a random order.</returns>
+    /// <returns>
+    /// A new sequence containing every element of <paramref name="source"/> in a
+    /// random permutation. The input sequence is not mutated.
+    /// </returns>
     /// <exception cref="ArgumentNullException">source is null.</exception>
     /// <example>
     /// <code>
@@ -260,10 +276,13 @@ public static class IEnumerableExtensions
 
     /// <summary>
     /// Wraps an <see cref="IEnumerable{T}"/> in a lazy iterator so the returned
-    /// sequence is guaranteed to NOT be a more concrete type (e.g., <see cref="List{T}"/>,
-    /// <see cref="System.Collections.Generic.ICollection{T}"/>, array). Useful in tests and
-    /// in production code that wants to defeat type-checks for fast paths that
-    /// pattern-match on the runtime type of the source.
+    /// sequence is guaranteed not to be assignable to any more concrete
+    /// enumerable type. Specifically, pattern-matching checks such as
+    /// <c>result is <see cref="List{T}"/></c>,
+    /// <c>result is <see cref="System.Collections.Generic.ICollection{T}"/></c>,
+    /// and <c>result is T[]</c> all return false. Useful in tests (and rarely in
+    /// production code) that want to defeat fast paths which pattern-match on
+    /// the runtime type of the source.
     /// </summary>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IEnumerable{T}"/> to wrap.</param>

--- a/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+*REMOVED*static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
@@ -48,8 +48,13 @@ public class ForEachTests
 
 
     [Fact]
-    public void ForEach_when_called_on_List_does_not_override_existing_ForEach_on_List()
+    public void ForEach_when_called_on_a_concrete_List_invokes_the_instance_method_not_the_extension()
     {
+        // Documents an intentional non-shadowing property: when `source` is statically
+        // typed as `List<T>`, C# resolves `source.ForEach(...)` to `List<T>.ForEach`
+        // (the BCL instance method) rather than to this library's extension. Our
+        // extension only takes effect when the source is typed as `IEnumerable<T>` —
+        // see the next test for that case.
         var source = new List<int> { 1, 2, 3, 4, 5 };
         var result = new List<int>();
         source.ForEach(i => result.Add(i * 2));

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<Version>1.2.0</Version>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>
@@ -14,8 +13,6 @@
 	<!-- Common packages for all frameworks -->
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.assert" Version="2.9.3" />
-		<PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
 	</ItemGroup>
 
 	<!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
@@ -86,10 +83,15 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<!-- .NET 8.0 - 10.0 specific packages (latest versions) -->
+	<!-- .NET 8.0 - 10.0 specific packages (latest versions).
+	     xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
+	     with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
+	     break the v2 test surface. The other TFM groups above pin
+	     2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
+	     TFM on the v2 runner family. -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'	">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
## Summary

Phase 1.6 finding. **Stacked on top of #166 (code polish).**

Every other public method on `IEnumerableExtensions` accepts `IEnumerable<T>?` (nullable) — ForEach, Do, IsEmpty, IsNullOrEmpty, None, None(predicate). Shuffle and ToEnumerable were the outliers, declaring non-nullable parameters even though their runtime null-check + `ArgumentNullException` matches the rest of the library exactly.

Now consistent:

- `Shuffle<T>(this IEnumerable<T>? source)`
- `ToEnumerable<T>(this IEnumerable<T>? source)`

`PublicAPI.Unshipped.txt` carries the `*REMOVED*` entries for the old signatures plus the new signatures. They will move to `PublicAPI.Shipped.txt` at the next release and the removed entries drop from Shipped at the same time.

## Behavior change?

No.

- Callers passing non-null source: no change.
- Callers passing `null!` (suppressing the warning): no change — still get `ArgumentNullException` at runtime.
- Callers in nullable-disabled code: no change.
- Callers in nullable-enabled code with an `IEnumerable<T>?` source: **strictly fewer warnings** (no longer need `source!` to silence the language warning).

## SemVer

Next release should bump MINOR (additive change to nullable annotations; no runtime regression).

## Test plan

- [x] All 54 tests pass on net10.0 Release locally
- [ ] CI green
- [ ] Coverage holds at 100%