### PR TITLE
CR: make Shuffle return-type opaque + add cheap array / ICollection fast paths

### DIFF
--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -226,6 +226,14 @@ public static class IEnumerableExtensions
     /// and the result is materialized before this method returns. The returned
     /// sequence does NOT preserve deferred-execution semantics — call <c>.Shuffle()</c>
     /// inside a LINQ pipeline only when that buffering cost is acceptable.
+    /// <para>
+    /// The runtime type of the returned sequence is intentionally opaque — pattern
+    /// matches such as <c>result is <see cref="List{T}"/></c>,
+    /// <c>result is <see cref="System.Collections.Generic.ICollection{T}"/></c>, and
+    /// <c>result is T[]</c> all return false. This prevents callers from mutating
+    /// the shuffle's internal buffer and matches the type-opacity contract of
+    /// <see cref="ToEnumerable{T}"/>.
+    /// </para>
     /// </remarks>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An IEnumerable{T} whose elements will be randomly ordered.</param>
@@ -247,19 +255,49 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(source));
         }
 
-        // Fisher-Yates shuffle implementation as suggested in the PR review
-        var list = source.ToList();
-        var rng = RandomSource;
-
-        for (var i = list.Count - 1; i > 0; i--)
+        // Build a mutable T[] buffer the cheapest way for the runtime type:
+        //   - T[]            : Array.Copy into a new T[] of the same length
+        //                      (avoids List<T>'s capacity field + indirection)
+        //   - ICollection<T> : preallocate a T[] and call CopyTo (no enumerator
+        //                      allocation, no growth resizing)
+        //   - else           : source.ToArray() (LINQ's IEnumerable<T> fallback)
+        // After Fisher-Yates we return through a yield iterator so the T[]
+        // buffer does NOT leak through pattern-match checks at the call site.
+        T[] buffer;
+        if (source is T[] arr)
         {
-            var j = rng.Next(i + 1);
-            var temp = list[i];
-            list[i] = list[j];
-            list[j] = temp;
+            buffer = new T[arr.Length];
+            Array.Copy(arr, buffer, arr.Length);
+        }
+        else if (source is ICollection<T> coll)
+        {
+            buffer = new T[coll.Count];
+            coll.CopyTo(buffer, 0);
+        }
+        else
+        {
+            buffer = source.ToArray();
         }
 
-        return list;
+        var rng = RandomSource;
+
+        for (var i = buffer.Length - 1; i > 0; i--)
+        {
+            var j = rng.Next(i + 1);
+            var temp = buffer[i];
+            buffer[i] = buffer[j];
+            buffer[j] = temp;
+        }
+
+        return Iterator(buffer);
+
+        static IEnumerable<T> Iterator(T[] shuffled)
+        {
+            foreach (var item in shuffled)
+            {
+                yield return item;
+            }
+        }
     }
 
 #if NET6_0_OR_GREATER

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
@@ -85,4 +85,99 @@ public class ShuffleTests
         Assert.Single(result);
         Assert.Equal(42, result[0]);
     }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_List()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is List<int>);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_ICollection()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is ICollection<int>);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_array()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is int[]);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_with_ICollection_source_exercises_collection_fast_path()
+    {
+        // Custom ICollection<T> that is NOT a List<T>, T[], or any LINQ-recognized
+        // collection — forces the `source is ICollection<T>` branch in Shuffle.
+        var source = new CountingCollection<int>(new[] { 1, 2, 3, 4, 5 });
+
+        var result = source.Shuffle().ToArray();
+
+        Assert.Equal(5, result.Length);
+        Assert.Equal(source.OrderBy(x => x), result.OrderBy(x => x));
+    }
+
+
+
+    [Fact]
+    public void Shuffle_with_pure_IEnumerable_source_exercises_ToArray_fallback()
+    {
+        // ToEnumerable wraps the source in a yield iterator that is NOT an
+        // ICollection<T>, forcing the `source.ToArray()` fallback in Shuffle.
+        var source = new[] { 1, 2, 3, 4, 5 }.ToEnumerable();
+
+        var result = source.Shuffle().ToArray();
+
+        Assert.Equal(5, result.Length);
+    }
+
+
+
+    private sealed class CountingCollection<T> : ICollection<T>
+    {
+        private readonly List<T> _inner;
+
+        public CountingCollection(IEnumerable<T> items)
+        {
+            _inner = new List<T>(items);
+        }
+
+        public int Count => _inner.Count;
+
+        public bool IsReadOnly => true;
+
+        public void Add(T item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(T item) => _inner.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _inner.GetEnumerator();
+
+        public bool Remove(T item) => throw new NotSupportedException();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+    }
 }


### PR DESCRIPTION
## Summary

Phase 1.6 + Phase 3 findings from the CR. **Stacked on #167.**

Previously `Shuffle()` returned its internal `List<T>` buffer cast to `IEnumerable<T>`, so `result is List<T>` returned true at the call site. Callers could downcast and mutate the shuffle's internal buffer — a subtle foot-gun that contradicted `ToEnumerable<T>`'s explicit type-opacity contract.

Now the returned sequence is opaque: `result is List<T>`, `result is ICollection<T>`, `result is T[]` all return **false**. Shuffled values, order randomness, eagerness, and exception contract are unchanged.

Implementation switches the internal buffer from `List<T>` to a raw `T[]` chosen via three runtime fast paths:

- `T[] arr` → `Array.Copy` (avoids List<T> capacity field + indirection)
- `ICollection<T> coll` → preallocate + `coll.CopyTo` (no enumerator allocation, no growth resizing)
- otherwise → `source.ToArray()` (LINQ's fallback)

Then Fisher-Yates runs in place on the array, and the array is returned through a `static` local-function yield iterator. The yield wrapper produces the opaque runtime type.

## SemVer

**MINOR** for the next release:

- Observable to callers (the pattern-match checks above), so not pure PATCH.
- Strictly additive in terms of guarantees — code that worked before still works; code that downcast to `List<T>` to mutate was relying on an undocumented implementation detail.

## Tests

Adds five new tests + a `CountingCollection<T>` helper:

- `Shuffle_result_is_not_assignable_to_List`
- `Shuffle_result_is_not_assignable_to_ICollection`
- `Shuffle_result_is_not_assignable_to_array`
- `Shuffle_with_ICollection_source_exercises_collection_fast_path`
- `Shuffle_with_pure_IEnumerable_source_exercises_ToArray_fallback`

54 → 59 tests; 59/59 pass on net10.0 Release.

## Test plan

- [x] Local build clean
- [x] 59/59 tests pass on net10.0 locally
- [ ] CI green
- [ ] Coverage holds at 100%
- [ ] ShuffleBenchmarks comparison posted to this PR (pending)