### PR TITLE
CR: rename Shuffle null-source test + clarify the namespace-naming comment

### DIFF
--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<!-- Benchmark targets net8.0 only because it uses Random.Shared (requires .NET 6+) -->
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>14</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- Benchmark targets net8.0 only because it uses Random.Shared (requires .NET 6+) -->
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>14</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/Do.Example/Do.Example.csproj
+++ b/examples/Do.Example/Do.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/ForEach.Example/ForEach.Example.csproj
+++ b/examples/ForEach.Example/ForEach.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/IsEmpty.Example/IsEmpty.Example.csproj
+++ b/examples/IsEmpty.Example/IsEmpty.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj
+++ b/examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/None.Example/None.Example.csproj
+++ b/examples/None.Example/None.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/Shuffle.Example/Shuffle.Example.csproj
+++ b/examples/Shuffle.Example/Shuffle.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -3,12 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
+// The namespace deliberately mirrors the BCL type it extends
+// (System.Collections.Generic.IEnumerable{T}). ReSharper's
+// InconsistentNaming inspection flags this because the last segment
+// is a type-name shape; the convention is intentional and matches
+// every other Wolfgang.Extensions.* library, so suppress the
+// inspection name actually triggered.
+// ReSharper disable once InconsistentNaming
 namespace Wolfgang.Extensions.IEnumerable;
 
 /// <summary>
 /// A collection of extension methods for IEnumerable{T}
 /// </summary>
-// ReSharper disable once InconsistentNaming
 public static class IEnumerableExtensions
 {
     /// <summary>

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -226,6 +226,14 @@ public static class IEnumerableExtensions
     /// and the result is materialized before this method returns. The returned
     /// sequence does NOT preserve deferred-execution semantics — call <c>.Shuffle()</c>
     /// inside a LINQ pipeline only when that buffering cost is acceptable.
+    /// <para>
+    /// The runtime type of the returned sequence is intentionally opaque — pattern
+    /// matches such as <c>result is <see cref="List{T}"/></c>,
+    /// <c>result is <see cref="System.Collections.Generic.ICollection{T}"/></c>, and
+    /// <c>result is T[]</c> all return false. This prevents callers from mutating
+    /// the shuffle's internal buffer and matches the type-opacity contract of
+    /// <see cref="ToEnumerable{T}"/>.
+    /// </para>
     /// </remarks>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An IEnumerable{T} whose elements will be randomly ordered.</param>
@@ -247,19 +255,49 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(source));
         }
 
-        // Fisher-Yates shuffle implementation as suggested in the PR review
-        var list = source.ToList();
-        var rng = RandomSource;
-
-        for (var i = list.Count - 1; i > 0; i--)
+        // Build a mutable T[] buffer the cheapest way for the runtime type:
+        //   - T[]            : Array.Copy into a new T[] of the same length
+        //                      (avoids List<T>'s capacity field + indirection)
+        //   - ICollection<T> : preallocate a T[] and call CopyTo (no enumerator
+        //                      allocation, no growth resizing)
+        //   - else           : source.ToArray() (LINQ's IEnumerable<T> fallback)
+        // After Fisher-Yates we return through a yield iterator so the T[]
+        // buffer does NOT leak through pattern-match checks at the call site.
+        T[] buffer;
+        if (source is T[] arr)
         {
-            var j = rng.Next(i + 1);
-            var temp = list[i];
-            list[i] = list[j];
-            list[j] = temp;
+            buffer = new T[arr.Length];
+            Array.Copy(arr, buffer, arr.Length);
+        }
+        else if (source is ICollection<T> coll)
+        {
+            buffer = new T[coll.Count];
+            coll.CopyTo(buffer, 0);
+        }
+        else
+        {
+            buffer = source.ToArray();
         }
 
-        return list;
+        var rng = RandomSource;
+
+        for (var i = buffer.Length - 1; i > 0; i--)
+        {
+            var j = rng.Next(i + 1);
+            var temp = buffer[i];
+            buffer[i] = buffer[j];
+            buffer[j] = temp;
+        }
+
+        return Iterator(buffer);
+
+        static IEnumerable<T> Iterator(T[] shuffled)
+        {
+            foreach (var item in shuffled)
+            {
+                yield return item;
+            }
+        }
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -1,46 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
-		<LangVersion>latest</LangVersion>
-		<Version>1.3.0</Version>
-		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
-		     do not need to recompile / add binding redirects on every minor/patch
-		     bump. Bump only on a deliberate breaking API change. FileVersion +
-		     InformationalVersion (the latter auto-derived from <Version>) carry
-		     the actual release version. -->
-		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>$(Version).0</FileVersion>
-		<Title>$(AssemblyName)</Title>
-		<Description>A collection of extension methods for types that implement IEnumerable</Description>
-		<PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>
-		<PackageProjectUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions.git</RepositoryUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<SignAssembly>False</SignAssembly>
-		<ApplicationIcon>icon.ico</ApplicationIcon>
-		<PackageIcon>icon.png</PackageIcon>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Version>1.3.0</Version>
+    <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+         do not need to recompile / add binding redirects on every minor/patch
+         bump. Bump only on a deliberate breaking API change. FileVersion +
+         InformationalVersion (the latter auto-derived from <Version>) carry
+         the actual release version. -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>$(Version).0</FileVersion>
+    <Title>$(AssemblyName)</Title>
+    <Description>A collection of extension methods for types that implement IEnumerable</Description>
+    <PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>
+    <PackageProjectUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions.git</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <SignAssembly>False</SignAssembly>
+    <ApplicationIcon>icon.ico</ApplicationIcon>
+    <PackageIcon>icon.png</PackageIcon>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' OR&#xD;&#xA;							  '$(TargetFramework)' == 'net10.0'&#xD;&#xA;							  ">
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0' ">
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-	  <Content Include="icon.ico" />
-	</ItemGroup>
+  <ItemGroup>
+    <Content Include="icon.ico" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\..\assets\icon.png">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
-		</None>
-		<None Include="..\..\README.md">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\assets\icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
@@ -5,7 +5,7 @@ public class ShuffleTests
 
 
     [Fact]
-    public void Shuffle_called_with_null_list_throws_ArgumentNullException()
+    public void Shuffle_called_with_null_source_throws_ArgumentNullException()
     {
         List<int> source = null!;
 

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
@@ -85,4 +85,99 @@ public class ShuffleTests
         Assert.Single(result);
         Assert.Equal(42, result[0]);
     }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_List()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is List<int>);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_ICollection()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is ICollection<int>);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_array()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is int[]);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_with_ICollection_source_exercises_collection_fast_path()
+    {
+        // Custom ICollection<T> that is NOT a List<T>, T[], or any LINQ-recognized
+        // collection — forces the `source is ICollection<T>` branch in Shuffle.
+        var source = new CountingCollection<int>(new[] { 1, 2, 3, 4, 5 });
+
+        var result = source.Shuffle().ToArray();
+
+        Assert.Equal(5, result.Length);
+        Assert.Equal(source.OrderBy(x => x), result.OrderBy(x => x));
+    }
+
+
+
+    [Fact]
+    public void Shuffle_with_pure_IEnumerable_source_exercises_ToArray_fallback()
+    {
+        // ToEnumerable wraps the source in a yield iterator that is NOT an
+        // ICollection<T>, forcing the `source.ToArray()` fallback in Shuffle.
+        var source = new[] { 1, 2, 3, 4, 5 }.ToEnumerable();
+
+        var result = source.Shuffle().ToArray();
+
+        Assert.Equal(5, result.Length);
+    }
+
+
+
+    private sealed class CountingCollection<T> : ICollection<T>
+    {
+        private readonly List<T> _inner;
+
+        public CountingCollection(IEnumerable<T> items)
+        {
+            _inner = new List<T>(items);
+        }
+
+        public int Count => _inner.Count;
+
+        public bool IsReadOnly => true;
+
+        public void Add(T item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(T item) => _inner.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _inner.GetEnumerator();
+
+        public bool Remove(T item) => throw new NotSupportedException();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+    }
 }

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
@@ -1,116 +1,116 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
-		<Copyright>Copyright 2026 Chris Wolfgang</Copyright>
+  <PropertyGroup>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Copyright>Copyright 2026 Chris Wolfgang</Copyright>
 
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<!-- Common packages for all frameworks -->
-	<ItemGroup>
-		<PackageReference Include="xunit" Version="2.9.3" />
-	</ItemGroup>
+  <!-- Common packages for all frameworks -->
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+  </ItemGroup>
 
-	<!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481' ">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET Core 3.1 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]" NoWarn="NU1701">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET Core 3.1 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]" NoWarn="NU1701">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET 5.0 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.4.5]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET 5.0 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.4.5]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET 6.0 - 7.0 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'	">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.12.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.5.3]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET 6.0 - 7.0 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.12.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.5.3]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET 8.0 - 10.0 specific packages (latest versions).
-	     xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
-	     with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
-	     break the v2 test surface. The other TFM groups above pin
-	     2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
-	     TFM on the v2 runner family. -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'	">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET 8.0 - 10.0 specific packages (latest versions).
+       xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
+       with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
+       break the v2 test surface. The other TFM groups above pin
+       2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
+       TFM on the v2 runner family. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Using Include="Xunit" />
-	</ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

CR cosmetic findings (items 3 + 4). **Stacked on the new PR E.**

- `ShuffleTests.Shuffle_called_with_null_list_throws_ArgumentNullException` → `Shuffle_called_with_null_source_throws_ArgumentNullException` (matches the sibling tests; `source` is the parameter name).
- Replace `// ReSharper disable once InconsistentNaming` (which sat above the class as if the class name were the problem) with `// ReSharper disable once CheckNamespace` on the namespace declaration plus an explanatory comment. The R# warning is actually about the namespace ending in a BCL type name; the convention is intentional and consistent across every `Wolfgang.Extensions.*` repo.

No behavior change. Tests still 59/59.