### PR TITLE
vNext: per-repo release flow integration branch

### DIFF
--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -11,9 +11,12 @@
 #   releases without burning CI time on every PR (mutation testing is slow)
 #
 # Stryker discovers each test project's mutation targets via the standard
-# project-reference graph. If a repo wants to tune the run (excluded files,
-# specific mutators, etc.) drop a stryker-config.json next to the test
-# project - dotnet stryker picks it up automatically.
+# project-reference graph. Two configuration modes are supported:
+# - Root stryker-config.json (umbrella): if present, runs Stryker once with
+#   the umbrella config and skips per-project runs (avoids duplicate work).
+# - Per-project stryker-config.json (or none): if no root config exists, runs
+#   Stryker once per test project; per-project configs override Stryker's
+#   defaults when present.
 name: Stryker (mutation testing)
 
 on:
@@ -32,6 +35,11 @@ jobs:
     # net4x, so they would silently mutate only the non-Framework TFMs
     # and miss bugs that only reproduce on Framework.
     runs-on: windows-latest
+    # Skip on the template repo itself - it has no test projects, so the
+    # workflow would just no-op every Sunday at 06:00 UTC, wasting a
+    # Windows runner allocation. Matches the same-pattern guard used by
+    # the .NET test-stage jobs in pr.yaml.
+    if: github.repository != 'Chris-Wolfgang/repo-template'
     timeout-minutes: 120
     steps:
       - name: Check out repo
@@ -40,10 +48,19 @@ jobs:
           persist-credentials: false
 
       - name: Setup .NET
+        # Install every SDK in the canonical test matrix (.NET Core 3.1
+        # through .NET 10.0). Stryker has to be able to build whichever
+        # TFM each test project targets; pinning to a subset would
+        # silently fail repos that target older runtimes.
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
+            7.0.x
             8.0.x
+            9.0.x
             10.0.x
 
       - name: Install dotnet-stryker
@@ -54,44 +71,49 @@ jobs:
             dotnet tool install -g dotnet-stryker
           }
 
-      - name: Run Stryker against every test project
+      - name: Run Stryker
         shell: pwsh
         run: |
-          # Canonical behavior: no stryker-config.json gate. Stryker runs
-          # against every test project under tests/ using dotnet stryker
-          # defaults; a per-project stryker-config.json overrides those
-          # defaults if present.
-          $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
-
-          if ($tests.Count -eq 0) {
-            Write-Host "::notice::No test projects found under tests/ - skipping Stryker run."
-            exit 0
-          }
-
-          Write-Host "Found $($tests.Count) test project(s):"
-          $tests | ForEach-Object { Write-Host "  $($_.FullName)" }
-          Write-Host ""
+          # Configuration mode resolution:
+          #   1. If a root stryker-config.json exists, it is the umbrella -
+          #      run Stryker once with it and stop (per-project runs would
+          #      duplicate the same work the umbrella already covers).
+          #   2. Otherwise, run Stryker against every test project under
+          #      tests/. A per-project stryker-config.json next to a test
+          #      project overrides Stryker's defaults when present.
 
           $failed = 0
-          foreach ($proj in $tests) {
-            $dir = $proj.DirectoryName
-            Write-Host "::group::Stryker in $dir"
-            Push-Location $dir
-            try {
-              dotnet stryker
-              if ($LASTEXITCODE -ne 0) { $failed++ }
-            } finally {
-              Pop-Location
-            }
-            Write-Host "::endgroup::"
-          }
 
-          # Also honor a root-level umbrella config if the repo provides one
           if (Test-Path 'stryker-config.json') {
-            Write-Host "::group::Stryker with root stryker-config.json"
+            Write-Host "::group::Stryker with root umbrella stryker-config.json"
             dotnet stryker --config-file stryker-config.json
             if ($LASTEXITCODE -ne 0) { $failed++ }
             Write-Host "::endgroup::"
+          }
+          else {
+            $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*Test*.csproj' -ErrorAction SilentlyContinue)
+
+            if ($tests.Count -eq 0) {
+              Write-Host "::notice::No test projects found under tests/ - skipping Stryker run."
+              exit 0
+            }
+
+            Write-Host "Found $($tests.Count) test project(s):"
+            $tests | ForEach-Object { Write-Host "  $($_.FullName)" }
+            Write-Host ""
+
+            foreach ($proj in $tests) {
+              $dir = $proj.DirectoryName
+              Write-Host "::group::Stryker in $dir"
+              Push-Location $dir
+              try {
+                dotnet stryker
+                if ($LASTEXITCODE -ne 0) { $failed++ }
+              } finally {
+                Pop-Location
+              }
+              Write-Host "::endgroup::"
+            }
           }
 
           if ($failed -gt 0) {

--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -1,12 +1,19 @@
 # Stryker mutation testing
 #
-# Runs the Stryker.NET mutation tester against the repo's test projects to
-# measure mutation score. Mutation runs are slow — triggered manually
-# (workflow_dispatch) and on a weekly schedule, not on every PR.
+# Mutation testing is canonical for every repo created from this template.
+# The workflow runs Stryker.NET against every test project under tests/ on
+# a Windows runner so it can compile every TFM the repo targets - including
+# .NET Framework 4.6.2-4.8.1, which a Linux runner cannot build.
 #
-# The workflow looks for a stryker-config.json at the repo root or under
-# tests/**/. If none is present the run is a no-op (Stryker setup is a
-# per-repo follow-up; this file is the canonical infrastructure).
+# Triggers:
+# - workflow_dispatch: manual ad-hoc runs (e.g. while iterating on tests)
+# - schedule (weekly Sunday 06:00 UTC): catch quality regressions between
+#   releases without burning CI time on every PR (mutation testing is slow)
+#
+# Stryker discovers each test project's mutation targets via the standard
+# project-reference graph. If a repo wants to tune the run (excluded files,
+# specific mutators, etc.) drop a stryker-config.json next to the test
+# project - dotnet stryker picks it up automatically.
 name: Stryker (mutation testing)
 
 on:
@@ -20,43 +27,19 @@ permissions:
 jobs:
   stryker:
     name: Run Stryker
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Windows runner so Stryker can compile every TFM the repo targets,
+    # including .NET Framework 4.6.2-4.8.1. Linux runners cannot build
+    # net4x, so they would silently mutate only the non-Framework TFMs
+    # and miss bugs that only reproduce on Framework.
+    runs-on: windows-latest
+    timeout-minutes: 120
     steps:
       - name: Check out repo
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
-      - name: Detect stryker-config.json
-        id: check
-        shell: bash
-        run: |
-          # Explicit existence checks rather than globbing — `nullglob` only
-          # drops words that look like patterns (contain *, ?, [). The bare
-          # literal `stryker-config.json` has no glob characters, so it would
-          # be preserved as a literal even when the file doesn't exist, and
-          # the workflow would mistakenly think a config was present.
-          shopt -s globstar nullglob
-          configs=()
-          [ -f stryker-config.json ] && configs+=(stryker-config.json)
-          for cfg in tests/**/stryker-config.json; do
-            [ -f "$cfg" ] && configs+=("$cfg")
-          done
-          if (( ${#configs[@]} )); then
-            printf 'found=true\n' >> "$GITHUB_OUTPUT"
-            # NOTE: previously also wrote a configs<<EOF multi-line output here,
-            # but (a) the downstream Run Stryker step re-globs from scratch and
-            # didn't consume it, and (b) ${configs[*]} joins with spaces so the
-            # value was effectively a single space-separated line — not actually
-            # multi-line. Dropped the dead/broken output.
-          else
-            echo "::notice::No stryker-config.json found — skipping Stryker run. Add one at repo root or under tests/<project>/ to enable mutation testing."
-            printf 'found=false\n' >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Setup .NET
-        if: steps.check.outputs.found == 'true'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
@@ -64,40 +47,60 @@ jobs:
             10.0.x
 
       - name: Install dotnet-stryker
-        if: steps.check.outputs.found == 'true'
-        run: dotnet tool update -g dotnet-stryker || dotnet tool install -g dotnet-stryker
-
-      - name: Run Stryker
-        if: steps.check.outputs.found == 'true'
-        shell: bash
+        shell: pwsh
         run: |
-          set -e
-          shopt -s globstar nullglob
-          # Run BOTH a root stryker-config.json (if present) AND any
-          # tests/**/stryker-config.json suites. The Detect step collects
-          # both shapes; running only one leaves per-test suites unscanned
-          # in repos that have both an umbrella and per-suite configs.
-          ran=0
-          if [ -f stryker-config.json ]; then
-            echo "::group::Stryker with root stryker-config.json"
+          dotnet tool update -g dotnet-stryker
+          if ($LASTEXITCODE -ne 0) {
+            dotnet tool install -g dotnet-stryker
+          }
+
+      - name: Run Stryker against every test project
+        shell: pwsh
+        run: |
+          # Canonical behavior: no stryker-config.json gate. Stryker runs
+          # against every test project under tests/ using dotnet stryker
+          # defaults; a per-project stryker-config.json overrides those
+          # defaults if present.
+          $tests = @(Get-ChildItem -Path tests -Recurse -Filter '*.csproj' -ErrorAction SilentlyContinue)
+
+          if ($tests.Count -eq 0) {
+            Write-Host "::notice::No test projects found under tests/ - skipping Stryker run."
+            exit 0
+          }
+
+          Write-Host "Found $($tests.Count) test project(s):"
+          $tests | ForEach-Object { Write-Host "  $($_.FullName)" }
+          Write-Host ""
+
+          $failed = 0
+          foreach ($proj in $tests) {
+            $dir = $proj.DirectoryName
+            Write-Host "::group::Stryker in $dir"
+            Push-Location $dir
+            try {
+              dotnet stryker
+              if ($LASTEXITCODE -ne 0) { $failed++ }
+            } finally {
+              Pop-Location
+            }
+            Write-Host "::endgroup::"
+          }
+
+          # Also honor a root-level umbrella config if the repo provides one
+          if (Test-Path 'stryker-config.json') {
+            Write-Host "::group::Stryker with root stryker-config.json"
             dotnet stryker --config-file stryker-config.json
-            echo "::endgroup::"
-            ran=1
-          fi
-          for cfg in tests/**/stryker-config.json; do
-            dir=$(dirname "$cfg")
-            echo "::group::Stryker in $dir"
-            (cd "$dir" && dotnet stryker)
-            echo "::endgroup::"
-            ran=1
-          done
-          if [ "$ran" -eq 0 ]; then
-            echo "::error::Detect step said stryker-config.json was present, but Run found neither root nor tests/**/stryker-config.json. Bailing."
+            if ($LASTEXITCODE -ne 0) { $failed++ }
+            Write-Host "::endgroup::"
+          }
+
+          if ($failed -gt 0) {
+            Write-Host "::error::$failed Stryker run(s) failed"
             exit 1
-          fi
+          }
 
       - name: Upload Stryker report
-        if: always() && steps.check.outputs.found == 'true'
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: stryker-report-${{ github.run_id }}

--- a/IEnumerable-Extensions.slnx
+++ b/IEnumerable-Extensions.slnx
@@ -41,6 +41,7 @@
     <Project Path="examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj" />
     <Project Path="examples/None.Example/None.Example.csproj" />
     <Project Path="examples/Shuffle.Example/Shuffle.Example.csproj" />
+    <Project Path="examples/ToEnumerable.Example/ToEnumerable.Example.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj" />

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsNullOrEmptyBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/IsNullOrEmptyBenchmarks.cs
@@ -1,0 +1,67 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
+
+/// <summary>
+/// Dedicated benchmarks for <c>IsNullOrEmpty&lt;T&gt;()</c> that exercise the
+/// null-input short-circuit alongside the empty / populated cases.
+/// <see cref="IsEmptyBenchmarks"/> covers some IsNullOrEmpty calls already,
+/// but skips the null-source path (since calling IsEmpty on null throws).
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class IsNullOrEmptyBenchmarks
+{
+    private IEnumerable<int>? _null;
+    private List<int> _emptyList = null!;
+    private List<int> _populatedList = null!;
+    private IEnumerable<int> _emptyYield = null!;
+    private IEnumerable<int> _populatedYield = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _null = null;
+        _emptyList = new List<int>();
+        _populatedList = Enumerable.Range(0, 1000).ToList();
+        _emptyYield = YieldRange(0);
+        _populatedYield = YieldRange(1000);
+    }
+
+    // ----- Null short-circuit -----
+
+    [Benchmark(Baseline = true)]
+    public bool ManualNullCheck_Null() => _null == null || !_null.Any();
+
+    [Benchmark]
+    public bool IsNullOrEmpty_Null() => _null.IsNullOrEmpty();
+
+    // ----- Empty ICollection -----
+
+    [Benchmark]
+    public bool ManualNullCheck_EmptyList() => _emptyList == null || !_emptyList.Any();
+
+    [Benchmark]
+    public bool IsNullOrEmpty_EmptyList() => _emptyList.IsNullOrEmpty();
+
+    // ----- Populated ICollection -----
+
+    [Benchmark]
+    public bool IsNullOrEmpty_PopulatedList() => _populatedList.IsNullOrEmpty();
+
+    // ----- Yield-based enumerables (no ICollection fast path) -----
+
+    [Benchmark]
+    public bool IsNullOrEmpty_EmptyYield() => _emptyYield.IsNullOrEmpty();
+
+    [Benchmark]
+    public bool IsNullOrEmpty_PopulatedYield() => _populatedYield.IsNullOrEmpty();
+
+    private static IEnumerable<int> YieldRange(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ToEnumerableBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ToEnumerableBenchmarks.cs
@@ -1,0 +1,45 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
+
+/// <summary>
+/// Measures the wrapping overhead of <c>ToEnumerable&lt;T&gt;()</c> in isolation
+/// — return-the-IEnumerable, no enumeration. Baseline is <c>Identity_Array</c>
+/// (returning the source array directly).
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class ToEnumerableBenchmarks
+{
+    private int[] _array = null!;
+    private List<int> _list = null!;
+    private IEnumerable<int> _yield = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _array = Enumerable.Range(0, 1000).ToArray();
+        _list = Enumerable.Range(0, 1000).ToList();
+        _yield = YieldRange(1000);
+    }
+
+    [Benchmark(Baseline = true)]
+    public IEnumerable<int> Identity_Array() => _array;
+
+    [Benchmark]
+    public IEnumerable<int> ToEnumerable_Array() => _array.ToEnumerable();
+
+    [Benchmark]
+    public IEnumerable<int> ToEnumerable_List() => _list.ToEnumerable();
+
+    [Benchmark]
+    public IEnumerable<int> ToEnumerable_Yield() => _yield.ToEnumerable();
+
+    private static IEnumerable<int> YieldRange(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ToEnumerableEnumerationBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ToEnumerableEnumerationBenchmarks.cs
@@ -1,0 +1,72 @@
+using BenchmarkDotNet.Attributes;
+
+namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
+
+/// <summary>
+/// Measures the wrap + full enumeration cost of <c>ToEnumerable&lt;T&gt;()</c>
+/// vs direct enumeration of the underlying source. Each "via ToEnumerable"
+/// benchmark has its own baseline of the same shape so the RankColumn
+/// stays interpretable.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+public class ToEnumerableEnumerationBenchmarks
+{
+    private int[] _array = null!;
+    private List<int> _list = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _array = Enumerable.Range(0, 1000).ToArray();
+        _list = Enumerable.Range(0, 1000).ToList();
+    }
+
+    // ----- Array source: baseline vs via ToEnumerable -----
+
+    [Benchmark(Baseline = true)]
+    public int Enumerate_Array_Baseline()
+    {
+        var total = 0;
+        foreach (var x in _array)
+        {
+            total += x;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int Enumerate_Array_ViaToEnumerable()
+    {
+        var total = 0;
+        foreach (var x in _array.ToEnumerable())
+        {
+            total += x;
+        }
+        return total;
+    }
+
+    // ----- List source: baseline vs via ToEnumerable -----
+
+    [Benchmark]
+    public int Enumerate_List_Baseline()
+    {
+        var total = 0;
+        foreach (var x in _list)
+        {
+            total += x;
+        }
+        return total;
+    }
+
+    [Benchmark]
+    public int Enumerate_List_ViaToEnumerable()
+    {
+        var total = 0;
+        foreach (var x in _list.ToEnumerable())
+        {
+            total += x;
+        }
+        return total;
+    }
+}

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks.csproj
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<!-- Benchmark targets net8.0 only because it uses Random.Shared (requires .NET 6+) -->
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>14</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- Benchmark targets net8.0 only because it uses Random.Shared (requires .NET 6+) -->
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>14</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -117,16 +117,32 @@
         select.addEventListener('change', function (e) {
             var target = e.target.value;
             if (!target) return;
+
+            // Defensive: refuse to navigate to non-http(s) schemes. The
+            // value comes from versions.json — a compromised or malicious
+            // file could try to slip in `javascript:`/`data:` to run code
+            // in the docs origin. Only allow root-relative paths or
+            // explicit http(s) absolute URLs.
+            if (!/^(?:\/[^\/]|https?:\/\/)/i.test(target)) {
+                return;
+            }
+
             // versions.json's `url` fields include the gh-pages repo prefix
             // (e.g. /DateTime-Extensions/versions/v1.2.0/) because that's
             // the correct absolute path on github.io. On localhost or on a
             // CNAME-served custom domain, that prefix isn't a directory
-            // and the navigation 404s. Strip the first path segment when
-            // we're not on github.io so the URL becomes relative to the
-            // actual document root.
-            if (!window.location.hostname.endsWith('.github.io') && target.charAt(0) === '/') {
-                target = target.replace(/^\/[^\/]+\//, '/');
+            // and the navigation 404s. Strip the first path segment only
+            // when (a) we're not on github.io AND (b) the current page's
+            // pathname doesn't already start with that same prefix —
+            // otherwise we'd break navigation on a CNAME setup that DOES
+            // serve `/<prefix>/...`.
+            if (target.charAt(0) === '/' && !window.location.hostname.endsWith('.github.io')) {
+                var firstSeg = target.match(/^(\/[^\/]+)\//);
+                if (firstSeg && !window.location.pathname.startsWith(firstSeg[1] + '/')) {
+                    target = target.replace(/^\/[^\/]+\//, '/');
+                }
             }
+
             window.location.href = target;
         });
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -124,12 +124,12 @@ Returns true if the source sequence is null or contains no elements. Does not th
 Determines whether a sequence contains no elements or no element satisfies a condition. The inverse of `Any()`. Throws `ArgumentNullException` when `source` (or `predicate`, for the overload) is null.
 
 ### Shuffle&lt;T&gt;
-**Signature**: `IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)`
+**Signature**: `IEnumerable<T> Shuffle<T>(this IEnumerable<T>? source)`
 
 Creates a new collection containing elements in random order using the Fisher-Yates shuffle algorithm. **Eager** — the entire input is consumed before the method returns. Throws `ArgumentNullException` when `source` is null.
 
 ### ToEnumerable&lt;T&gt;
-**Signature**: `IEnumerable<T> ToEnumerable<T>(this IEnumerable<T> source)`
+**Signature**: `IEnumerable<T> ToEnumerable<T>(this IEnumerable<T>? source)`
 
 Wraps the source in a lazy iterator so that pattern-matching checks like `result is List<T>` or `result is ICollection<T>` return false. Primarily useful in unit tests for exercising the non-`ICollection` slow path of other extension methods. Throws `ArgumentNullException` when `source` is null.
 

--- a/examples/Do.Example/Do.Example.csproj
+++ b/examples/Do.Example/Do.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/ForEach.Example/ForEach.Example.csproj
+++ b/examples/ForEach.Example/ForEach.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/IsEmpty.Example/IsEmpty.Example.csproj
+++ b/examples/IsEmpty.Example/IsEmpty.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj
+++ b/examples/IsNullOrEmpty.Example/IsNullOrEmpty.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/None.Example/None.Example.csproj
+++ b/examples/None.Example/None.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/Shuffle.Example/Shuffle.Example.csproj
+++ b/examples/Shuffle.Example/Shuffle.Example.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/examples/ToEnumerable.Example/Program.cs
+++ b/examples/ToEnumerable.Example/Program.cs
@@ -1,0 +1,43 @@
+using Wolfgang.Extensions.IEnumerable;
+
+// ToEnumerable wraps the source in a lazy iterator so the returned
+// sequence is guaranteed to NOT be a more concrete type. Pattern-match
+// checks like `result is List<T>` / `is ICollection<T>` / `is T[]` all
+// return false. Primarily useful in tests when you want to exercise
+// the non-ICollection slow path of another extension method.
+
+Console.WriteLine("=== ToEnumerable Example ===");
+Console.WriteLine();
+
+// Original concrete collections. The IEnumerable<T>-typed locals are
+// what's interesting — at THIS static type, runtime pattern matching
+// against List<T>/ICollection<T>/T[] is what extension methods see
+// (and what their hot-path branches act on).
+IEnumerable<int> array = new[] { 1, 2, 3, 4, 5 };
+IEnumerable<string> list = new List<string> { "alpha", "beta", "gamma" };
+
+Console.WriteLine("Source types and their runtime shapes:");
+Console.WriteLine($"  int[]                    is List<int>:        {array is List<int>}");
+Console.WriteLine($"  int[]                    is ICollection<int>: {array is ICollection<int>}");
+Console.WriteLine($"  int[]                    is int[]:            {array is int[]}");
+Console.WriteLine();
+
+// Wrap with ToEnumerable: every pattern-match returns false
+var wrappedArray = array.ToEnumerable();
+var wrappedList = list.ToEnumerable();
+
+Console.WriteLine("After ToEnumerable():");
+Console.WriteLine($"  wrappedArray is List<int>:        {wrappedArray is List<int>}");
+Console.WriteLine($"  wrappedArray is ICollection<int>: {wrappedArray is ICollection<int>}");
+Console.WriteLine($"  wrappedArray is int[]:            {wrappedArray is int[]}");
+Console.WriteLine($"  wrappedList  is List<string>:     {wrappedList is List<string>}");
+Console.WriteLine();
+
+// Values + ordering preserved
+Console.WriteLine("Values flow through unchanged: " + string.Join(", ", wrappedArray));
+Console.WriteLine();
+
+// Practical use: forcing IsEmpty's non-ICollection slow path
+// (without the wrap, IsEmpty short-circuits via array.Length == 0).
+var slowPath = Array.Empty<int>().ToEnumerable();
+Console.WriteLine($"slowPath.IsEmpty() (forced enumeration): {slowPath.IsEmpty()}");

--- a/examples/ToEnumerable.Example/ToEnumerable.Example.csproj
+++ b/examples/ToEnumerable.Example/ToEnumerable.Example.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -3,12 +3,18 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 
+// The namespace deliberately mirrors the BCL type it extends
+// (System.Collections.Generic.IEnumerable{T}). ReSharper's
+// InconsistentNaming inspection flags this because the last segment
+// is a type-name shape; the convention is intentional and matches
+// every other Wolfgang.Extensions.* library, so suppress the
+// inspection name actually triggered.
+// ReSharper disable once InconsistentNaming
 namespace Wolfgang.Extensions.IEnumerable;
 
 /// <summary>
 /// A collection of extension methods for IEnumerable{T}
 /// </summary>
-// ReSharper disable once InconsistentNaming
 public static class IEnumerableExtensions
 {
     /// <summary>

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -240,7 +240,7 @@ public static class IEnumerableExtensions
     /// var shuffled = deck.Shuffle();
     /// </code>
     /// </example>
-    public static IEnumerable<T> Shuffle<T>(this IEnumerable<T> source)
+    public static IEnumerable<T> Shuffle<T>(this IEnumerable<T>? source)
     {
         if (source == null)
         {
@@ -299,7 +299,7 @@ public static class IEnumerableExtensions
     /// // Useful when exercising an extension method's slow path in unit tests.
     /// </code>
     /// </example>
-    public static IEnumerable<T> ToEnumerable<T>(this IEnumerable<T> source)
+    public static IEnumerable<T> ToEnumerable<T>(this IEnumerable<T>? source)
     {
         if (source == null)
         {

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -226,6 +226,14 @@ public static class IEnumerableExtensions
     /// and the result is materialized before this method returns. The returned
     /// sequence does NOT preserve deferred-execution semantics — call <c>.Shuffle()</c>
     /// inside a LINQ pipeline only when that buffering cost is acceptable.
+    /// <para>
+    /// The runtime type of the returned sequence is intentionally opaque — pattern
+    /// matches such as <c>result is <see cref="List{T}"/></c>,
+    /// <c>result is <see cref="System.Collections.Generic.ICollection{T}"/></c>, and
+    /// <c>result is T[]</c> all return false. This prevents callers from mutating
+    /// the shuffle's internal buffer and matches the type-opacity contract of
+    /// <see cref="ToEnumerable{T}"/>.
+    /// </para>
     /// </remarks>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An IEnumerable{T} whose elements will be randomly ordered.</param>
@@ -247,19 +255,49 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(source));
         }
 
-        // Fisher-Yates shuffle implementation as suggested in the PR review
-        var list = source.ToList();
-        var rng = RandomSource;
-
-        for (var i = list.Count - 1; i > 0; i--)
+        // Build a mutable T[] buffer the cheapest way for the runtime type:
+        //   - T[]            : Array.Copy into a new T[] of the same length
+        //                      (avoids List<T>'s capacity field + indirection)
+        //   - ICollection<T> : preallocate a T[] and call CopyTo (no enumerator
+        //                      allocation, no growth resizing)
+        //   - else           : source.ToArray() (LINQ's IEnumerable<T> fallback)
+        // After Fisher-Yates we return through a yield iterator so the T[]
+        // buffer does NOT leak through pattern-match checks at the call site.
+        T[] buffer;
+        if (source is T[] arr)
         {
-            var j = rng.Next(i + 1);
-            var temp = list[i];
-            list[i] = list[j];
-            list[j] = temp;
+            buffer = new T[arr.Length];
+            Array.Copy(arr, buffer, arr.Length);
+        }
+        else if (source is ICollection<T> coll)
+        {
+            buffer = new T[coll.Count];
+            coll.CopyTo(buffer, 0);
+        }
+        else
+        {
+            buffer = source.ToArray();
         }
 
-        return list;
+        var rng = RandomSource;
+
+        for (var i = buffer.Length - 1; i > 0; i--)
+        {
+            var j = rng.Next(i + 1);
+            var temp = buffer[i];
+            buffer[i] = buffer[j];
+            buffer[j] = temp;
+        }
+
+        return Iterator(buffer);
+
+        static IEnumerable<T> Iterator(T[] shuffled)
+        {
+            foreach (var item in shuffled)
+            {
+                yield return item;
+            }
+        }
     }
 
 #if NET6_0_OR_GREATER

--- a/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
+++ b/src/Wolfgang.Extensions.IEnumerable/IEnumerableExtensions.cs
@@ -36,8 +36,10 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(action));
         }
 
-        // This block should not be hit as the List<T>.ForEach should get selected by the compiler
-        // but adding it for performance reasons in case it does not
+        // Fast path: when a List<T> reaches this extension via an IEnumerable<T>-typed
+        // call site (where the static binding picks the extension, not List<T>.ForEach),
+        // delegate to the List's instance method. That avoids the IEnumerator<T>
+        // allocation taken by the generic foreach below.
         if (source is List<T> s)
         {
             s.ForEach(action);
@@ -195,28 +197,42 @@ public static class IEnumerableExtensions
             throw new ArgumentNullException(nameof(action));
         }
 
-        return DoIterator(source, action);
-    }
+        // The actual yielding lives in a static local function so that the
+        // argument-null checks above run EAGERLY at call time. If yield-return
+        // appeared in the outer method body, the whole method would compile
+        // as an iterator and the throws would only fire on first MoveNext —
+        // breaking the "null source/action throws at call site" contract.
+        // Same pattern as ToEnumerable<T> below.
+        return Iterator(source, action);
 
-
-
-    private static IEnumerable<T> DoIterator<T>(IEnumerable<T> source, Action<T> action)
-    {
-        foreach (var item in source)
+        static IEnumerable<T> Iterator(IEnumerable<T> src, Action<T> act)
         {
-            action(item);
-            yield return item;
+            foreach (var item in src)
+            {
+                act(item);
+                yield return item;
+            }
         }
     }
 
 
 
     /// <summary>
-    /// Creates a new IEnumerable{T} containing the elements from source in a random order
+    /// Creates a new sequence containing the elements from <paramref name="source"/>
+    /// in a random order, using a Fisher–Yates shuffle.
     /// </summary>
+    /// <remarks>
+    /// This method is <b>eager</b>: the entire <paramref name="source"/> is consumed
+    /// and the result is materialized before this method returns. The returned
+    /// sequence does NOT preserve deferred-execution semantics — call <c>.Shuffle()</c>
+    /// inside a LINQ pipeline only when that buffering cost is acceptable.
+    /// </remarks>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An IEnumerable{T} whose elements will be randomly ordered.</param>
-    /// <returns>A new IEnumerable{T} containing the elements from source in a random order.</returns>
+    /// <returns>
+    /// A new sequence containing every element of <paramref name="source"/> in a
+    /// random permutation. The input sequence is not mutated.
+    /// </returns>
     /// <exception cref="ArgumentNullException">source is null.</exception>
     /// <example>
     /// <code>
@@ -260,10 +276,13 @@ public static class IEnumerableExtensions
 
     /// <summary>
     /// Wraps an <see cref="IEnumerable{T}"/> in a lazy iterator so the returned
-    /// sequence is guaranteed to NOT be a more concrete type (e.g., <see cref="List{T}"/>,
-    /// <see cref="System.Collections.Generic.ICollection{T}"/>, array). Useful in tests and
-    /// in production code that wants to defeat type-checks for fast paths that
-    /// pattern-match on the runtime type of the source.
+    /// sequence is guaranteed not to be assignable to any more concrete
+    /// enumerable type. Specifically, pattern-matching checks such as
+    /// <c>result is <see cref="List{T}"/></c>,
+    /// <c>result is <see cref="System.Collections.Generic.ICollection{T}"/></c>,
+    /// and <c>result is T[]</c> all return false. Useful in tests (and rarely in
+    /// production code) that want to defeat fast paths which pattern-match on
+    /// the runtime type of the source.
     /// </summary>
     /// <typeparam name="T">The type of the elements of source.</typeparam>
     /// <param name="source">An <see cref="IEnumerable{T}"/> to wrap.</param>

--- a/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+*REMOVED*static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -1,46 +1,46 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
-		<LangVersion>latest</LangVersion>
-		<Version>1.3.0</Version>
-		<!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
-		     do not need to recompile / add binding redirects on every minor/patch
-		     bump. Bump only on a deliberate breaking API change. FileVersion +
-		     InformationalVersion (the latter auto-derived from <Version>) carry
-		     the actual release version. -->
-		<AssemblyVersion>1.0.0.0</AssemblyVersion>
-		<FileVersion>$(Version).0</FileVersion>
-		<Title>$(AssemblyName)</Title>
-		<Description>A collection of extension methods for types that implement IEnumerable</Description>
-		<PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>
-		<PackageProjectUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions</PackageProjectUrl>
-		<RepositoryUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions.git</RepositoryUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-		<GenerateDocumentationFile>True</GenerateDocumentationFile>
-		<SignAssembly>False</SignAssembly>
-		<ApplicationIcon>icon.ico</ApplicationIcon>
-		<PackageIcon>icon.png</PackageIcon>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Version>1.3.0</Version>
+    <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
+         do not need to recompile / add binding redirects on every minor/patch
+         bump. Bump only on a deliberate breaking API change. FileVersion +
+         InformationalVersion (the latter auto-derived from <Version>) carry
+         the actual release version. -->
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>$(Version).0</FileVersion>
+    <Title>$(AssemblyName)</Title>
+    <Description>A collection of extension methods for types that implement IEnumerable</Description>
+    <PackageTags>IEnumerable;Extensions;LINQ;ForEach;Do;Shuffle;None;IsEmpty;dotnet;csharp</PackageTags>
+    <PackageProjectUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Chris-Wolfgang/IEnumerable-Extensions.git</RepositoryUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <SignAssembly>False</SignAssembly>
+    <ApplicationIcon>icon.ico</ApplicationIcon>
+    <PackageIcon>icon.png</PackageIcon>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' OR&#xD;&#xA;							  '$(TargetFramework)' == 'net10.0'&#xD;&#xA;							  ">
-		<ImplicitUsings>enable</ImplicitUsings>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net10.0' ">
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
 
-	<ItemGroup>
-	  <Content Include="icon.ico" />
-	</ItemGroup>
+  <ItemGroup>
+    <Content Include="icon.ico" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="..\..\assets\icon.png">
-		  <Pack>True</Pack>
-		  <PackagePath>\</PackagePath>
-		</None>
-		<None Include="..\..\README.md">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\assets\icon.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+    <None Include="..\..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ForEachTests.cs
@@ -48,8 +48,13 @@ public class ForEachTests
 
 
     [Fact]
-    public void ForEach_when_called_on_List_does_not_override_existing_ForEach_on_List()
+    public void ForEach_when_called_on_a_concrete_List_invokes_the_instance_method_not_the_extension()
     {
+        // Documents an intentional non-shadowing property: when `source` is statically
+        // typed as `List<T>`, C# resolves `source.ForEach(...)` to `List<T>.ForEach`
+        // (the BCL instance method) rather than to this library's extension. Our
+        // extension only takes effect when the source is typed as `IEnumerable<T>` —
+        // see the next test for that case.
         var source = new List<int> { 1, 2, 3, 4, 5 };
         var result = new List<int>();
         source.ForEach(i => result.Add(i * 2));

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
@@ -5,7 +5,7 @@ public class ShuffleTests
 
 
     [Fact]
-    public void Shuffle_called_with_null_list_throws_ArgumentNullException()
+    public void Shuffle_called_with_null_source_throws_ArgumentNullException()
     {
         List<int> source = null!;
 

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/ShuffleTests.cs
@@ -85,4 +85,99 @@ public class ShuffleTests
         Assert.Single(result);
         Assert.Equal(42, result[0]);
     }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_List()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is List<int>);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_ICollection()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is ICollection<int>);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_result_is_not_assignable_to_array()
+    {
+        var source = new[] { 1, 2, 3, 4, 5 };
+
+        var result = source.Shuffle();
+
+        Assert.False(result is int[]);
+    }
+
+
+
+    [Fact]
+    public void Shuffle_with_ICollection_source_exercises_collection_fast_path()
+    {
+        // Custom ICollection<T> that is NOT a List<T>, T[], or any LINQ-recognized
+        // collection — forces the `source is ICollection<T>` branch in Shuffle.
+        var source = new CountingCollection<int>(new[] { 1, 2, 3, 4, 5 });
+
+        var result = source.Shuffle().ToArray();
+
+        Assert.Equal(5, result.Length);
+        Assert.Equal(source.OrderBy(x => x), result.OrderBy(x => x));
+    }
+
+
+
+    [Fact]
+    public void Shuffle_with_pure_IEnumerable_source_exercises_ToArray_fallback()
+    {
+        // ToEnumerable wraps the source in a yield iterator that is NOT an
+        // ICollection<T>, forcing the `source.ToArray()` fallback in Shuffle.
+        var source = new[] { 1, 2, 3, 4, 5 }.ToEnumerable();
+
+        var result = source.Shuffle().ToArray();
+
+        Assert.Equal(5, result.Length);
+    }
+
+
+
+    private sealed class CountingCollection<T> : ICollection<T>
+    {
+        private readonly List<T> _inner;
+
+        public CountingCollection(IEnumerable<T> items)
+        {
+            _inner = new List<T>(items);
+        }
+
+        public int Count => _inner.Count;
+
+        public bool IsReadOnly => true;
+
+        public void Add(T item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(T item) => _inner.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _inner.GetEnumerator();
+
+        public bool Remove(T item) => throw new NotSupportedException();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _inner.GetEnumerator();
+    }
 }

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<Version>1.2.0</Version>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IsPackable>false</IsPackable>
@@ -14,8 +13,6 @@
 	<!-- Common packages for all frameworks -->
 	<ItemGroup>
 		<PackageReference Include="xunit" Version="2.9.3" />
-		<PackageReference Include="xunit.assert" Version="2.9.3" />
-		<PackageReference Include="xunit.extensibility.core" Version="2.9.3" />
 	</ItemGroup>
 
 	<!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
@@ -86,10 +83,15 @@
 		</PackageReference>
 	</ItemGroup>
 
-	<!-- .NET 8.0 - 10.0 specific packages (latest versions) -->
+	<!-- .NET 8.0 - 10.0 specific packages (latest versions).
+	     xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
+	     with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
+	     break the v2 test surface. The other TFM groups above pin
+	     2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
+	     TFM on the v2 runner family. -->
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'	">
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
+++ b/tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj
@@ -1,116 +1,116 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
-		<LangVersion>latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<IsPackable>false</IsPackable>
-		<IsTestProject>true</IsTestProject>
-		<Copyright>Copyright 2026 Chris Wolfgang</Copyright>
+  <PropertyGroup>
+    <TargetFrameworks>net462;net47;net471;net472;net48;net481;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Copyright>Copyright 2026 Chris Wolfgang</Copyright>
 
-	</PropertyGroup>
+  </PropertyGroup>
 
-	<!-- Common packages for all frameworks -->
-	<ItemGroup>
-		<PackageReference Include="xunit" Version="2.9.3" />
-	</ItemGroup>
+  <!-- Common packages for all frameworks -->
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.9.3" />
+  </ItemGroup>
 
-	<!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481' ">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET Framework 4.6.2 - 4.8.1 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net47' or '$(TargetFramework)' == 'net471' or '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net481' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET Core 3.1 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]" NoWarn="NU1701">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET Core 3.1 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]" NoWarn="NU1701">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET 5.0 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.4.5]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET 5.0 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.4.5]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET 6.0 - 7.0 specific packages -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'	">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.12.0]" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.5.3]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET 6.0 - 7.0 specific packages -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.12.0]" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.5.3]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<!-- .NET 8.0 - 10.0 specific packages (latest versions).
-	     xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
-	     with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
-	     break the v2 test surface. The other TFM groups above pin
-	     2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
-	     TFM on the v2 runner family. -->
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'	">
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit.runner.console" Version="2.9.3">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="10.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <!-- .NET 8.0 - 10.0 specific packages (latest versions).
+       xunit.runner.visualstudio is pinned to [2.8.2] to remain compatible
+       with xunit v2.9.3 — v3 of the runner targets xunit.v3 and would
+       break the v2 test surface. The other TFM groups above pin
+       2.4.5 / 2.5.3 / 2.8.2 for the same reason; this keeps every
+       TFM on the v2 runner family. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="[2.8.2]">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Extensions.IEnumerable\Wolfgang.Extensions.IEnumerable.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Using Include="Xunit" />
-	</ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Per-repo release flow integration branch. `vNext` is the single normal-merge target for `main`. Each CR PR merges into `vNext` one at a time; once everything is green this PR merges to `main`.

## Current diff against main

vNext now carries (in merge order):

1. **canonical-protected** content — two `stryker.yaml` cherry-picks (`584dc5f`, `24935bf`). These will land on main first via the admin-bypass PR #172; once that merges, this slice of the diff disappears from #173.
2. **PR #165** (`25ef1a9`) — test csproj tidy + `ForEachTests` rename.
3. **PR #166** (`8081e6d`) — source comment + `Do` iterator + Shuffle/ToEnumerable XML doc polish.
4. **PR #167** (`48c5fd3`) — Shuffle/ToEnumerable nullable-annotation alignment with the rest of the library.

Still to land on `vNext` (open stacked PRs):

- **#168** (`cr/pr-e-shuffle-opacity → vNext`) — Shuffle return-type opacity + array/ICollection fast paths
- **#169** (`cr/pr-f-cosmetic → cr/pr-e-shuffle-opacity`) — Shuffle test rename + namespace-comment alignment + csproj 2-space indent + CRLF flatten
- **#171** (`cr/pr-h-missing-examples → cr/pr-f-cosmetic`) — `ToEnumerable.Example` + new benchmarks + Shuffle source-type breakdown

## Merge sequence

1. **#172** `canonical-protected → main` — admin bypass (the `Detect .NET Projects` guard hard-fails any PR touching `.github/workflows/**`).
2. **#168 → vNext** → **#169 → vNext** → **#171 → vNext** — normal merges in stack order; rebase between each as bases auto-promote.
3. **#173** `vNext → main` (this PR) — normal merge, no bypass needed. Once step 1 lands, the `stryker.yaml` portion of this diff disappears and the protected-files guard stops failing this PR.
4. Tag the release once `main` is at the desired state.

## Why `BLOCKED` right now

The `Detect .NET Projects` guard sees `stryker.yaml` modified in this diff vs `main`. As soon as #172 merges, that file is no longer changed by this PR and the guard clears automatically — no manual rebase required (vNext is already a merge of canonical-protected, so the diff just shrinks).