### PR TITLE
sync: canonical version-picker.js + reformat ToEnumerable.Example.csproj

### DIFF
--- a/docfx_project/public/version-picker.js
+++ b/docfx_project/public/version-picker.js
@@ -117,16 +117,32 @@
         select.addEventListener('change', function (e) {
             var target = e.target.value;
             if (!target) return;
+
+            // Defensive: refuse to navigate to non-http(s) schemes. The
+            // value comes from versions.json — a compromised or malicious
+            // file could try to slip in `javascript:`/`data:` to run code
+            // in the docs origin. Only allow root-relative paths or
+            // explicit http(s) absolute URLs.
+            if (!/^(?:\/[^\/]|https?:\/\/)/i.test(target)) {
+                return;
+            }
+
             // versions.json's `url` fields include the gh-pages repo prefix
             // (e.g. /DateTime-Extensions/versions/v1.2.0/) because that's
             // the correct absolute path on github.io. On localhost or on a
             // CNAME-served custom domain, that prefix isn't a directory
-            // and the navigation 404s. Strip the first path segment when
-            // we're not on github.io so the URL becomes relative to the
-            // actual document root.
-            if (!window.location.hostname.endsWith('.github.io') && target.charAt(0) === '/') {
-                target = target.replace(/^\/[^\/]+\//, '/');
+            // and the navigation 404s. Strip the first path segment only
+            // when (a) we're not on github.io AND (b) the current page's
+            // pathname doesn't already start with that same prefix —
+            // otherwise we'd break navigation on a CNAME setup that DOES
+            // serve `/<prefix>/...`.
+            if (target.charAt(0) === '/' && !window.location.hostname.endsWith('.github.io')) {
+                var firstSeg = target.match(/^(\/[^\/]+)\//);
+                if (firstSeg && !window.location.pathname.startsWith(firstSeg[1] + '/')) {
+                    target = target.replace(/^\/[^\/]+\//, '/');
+                }
             }
+
             window.location.href = target;
         });
 


### PR DESCRIPTION
## Summary

Two unprotected drift fixes for vNext.

### `docfx_project/public/version-picker.js`

Verbatim pull from `Chris-Wolfgang/repo-template/main`. Two improvements missing in this repo:

1. **Scheme allowlist** — refuse to navigate to anything that isn't `/...` or `http(s)://...`. Closes an XSS vector where a compromised `versions.json` could slip `javascript:` / `data:` into the dropdown and execute in the docs origin.
2. **CNAME path-prefix fix** — the picker previously stripped the first path segment unconditionally on non-`github.io` hosts. That broke CNAME setups serving docs under `/<prefix>/...`. Now the strip only runs when the current pathname doesn't already start with that prefix.

### `examples/ToEnumerable.Example/ToEnumerable.Example.csproj`

Reformat to 2-space indent matching `.editorconfig` `[*.csproj] indent_size = 2` and every other csproj in the repo. The file was scaffolded at 4-space in PR #171 before PR #170's tab→space reformat ran; PR #170's conversion only matched files with leading tabs, so this one drifted.

## Stack

This PR → `vNext` → `main` (via #173). Companion to PR #174 (protected workflow sync, admin bypass to `main` directly).