### PR TITLE
T3: enable Stryker.NET mutation testing — add stryker-config.json

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,0 +1,19 @@
+{
+  "stryker-config": {
+    "project": "src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj",
+    "test-projects": [
+      "tests/Wolfgang.Extensions.IEnumerable.Tests.Unit/Wolfgang.Extensions.IEnumerable.Tests.Unit.csproj"
+    ],
+    "target-framework": "net10.0",
+    "reporters": [
+      "html",
+      "json",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 90,
+      "low": 75,
+      "break": 0
+    }
+  }
+}


### PR DESCRIPTION
Adds stryker-config.json so the canonical .github/workflows/stryker.yaml (already shipped via the T3 fanout) actually runs mutation testing on this repo. Until this file lands the workflow detects no config and exits as a no-op.

target-framework: net10.0 (mutation runs one TFM at a time)
thresholds.break: 0 (keep CI green while baseline establishes)

Pattern lifted from IComparable-Extensions PR #136 — 100% mutation score on the v1.1.1 test surface.