### PR TITLE
release: prep v1.4.0 (version bump + PublicAPI promote + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [1.4.0] - 2026-06-03
+
+### Added
+
+- `examples/ToEnumerable.Example/` — new example project demonstrating
+  the `ToEnumerable<T>` type-opacity contract, mirroring the per-method
+  example layout used for the other public methods.
+- New benchmark suites: `IsNullOrEmptyBenchmarks` (fills the null-source
+  short-circuit gap left by `IsEmptyBenchmarks`), `ToEnumerableBenchmarks`
+  (wrap-only overhead), and `ToEnumerableEnumerationBenchmarks`
+  (wrap + enumeration cost with apples-to-apples baselines).
+- `Shuffle<T>` now has three internal fast paths chosen by the runtime
+  source type, removing the previous "always allocate a `List<T>`" cost:
+  - `T[]` source → `Array.Copy` into a new `T[]`
+  - `ICollection<T>` source → preallocate `T[]` + `CopyTo` (no enumerator
+    allocation, no growth resizing)
+  - pure `IEnumerable<T>` → `source.ToArray()` fallback
+
+### Changed
+
+- **Behavior**: `Shuffle<T>()` return type is now opaque. Pattern matches
+  like `result is List<T>`, `result is ICollection<T>`, and `result is T[]`
+  all return `false`. Previously the method returned its internal
+  `List<T>` buffer cast to `IEnumerable<T>`, letting callers downcast and
+  mutate the buffer. Shuffled values, order randomness, eagerness, and
+  exception contract are unchanged.
+- **Public API**: `Shuffle<T>(this IEnumerable<T>?)` and
+  `ToEnumerable<T>(this IEnumerable<T>?)` — parameter nullability aligned
+  with every other public method on `IEnumerableExtensions`. Annotation
+  change only; runtime behavior unchanged (both still throw
+  `ArgumentNullException` on a null source). Strictly additive — callers
+  passing `IEnumerable<T>?` sources no longer need the `!` null-forgiving
+  operator.
+- `Do<T>()` internal iterator refactored to a `static` local function
+  (matching the v1.3.0 `ToEnumerable<T>` pattern). No public surface
+  change; the eager null-checks still fire at call time.
+- Test csproj: pin `xunit.runner.visualstudio` to `[2.8.2]` on net8/9/10
+  matching every other TFM group, keeping all targets on the xunit v2
+  runner family.
+- csproj indentation normalized to 2 spaces across every project file,
+  matching `.editorconfig`'s `[*.csproj] indent_size = 2`.
+- Workflow drift sync from `Chris-Wolfgang/repo-template`:
+  - `docfx.yaml` — adds the `overlay_canonical_docs_assets` workflow
+    input + step so rebuilds of older tags can backfill the canonical
+    version-picker UI onto pre-picker docs.
+  - `codeql.yaml`, `release.yaml` — cosmetic alignment.
+
+### Fixed
+
+- `docs/readme.md` IsEmpty/IsNullOrEmpty section structure + signatures
+  updated to match the live public surface.
+- `tests/ForEachTests.cs` — vacuous-looking test renamed to
+  `ForEach_when_called_on_a_concrete_List_invokes_the_instance_method_not_the_extension`
+  with an explanatory comment, making clear it documents an intentional
+  NON-shadowing property of the extension (the previous name implied it
+  was testing the extension).
+
+### Security
+
+- `docfx_project/public/version-picker.js` — defensive scheme allowlist
+  on dropdown navigation. The picker now refuses to navigate to anything
+  that isn't a root-relative path (`/...`) or an explicit `http(s)://`
+  URL. Closes an XSS vector where a compromised `versions.json` could
+  slip a `javascript:` or `data:` URL into the dropdown and execute
+  script in the docs origin.
+- `docfx_project/public/version-picker.js` — CNAME path-prefix handling
+  fix: stop stripping the first path segment on custom-domain setups
+  that legitimately serve docs under `/<prefix>/...`.
+
 ## [1.3.0] - 2026-05-30
 
 ### Added
@@ -143,7 +212,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fisher-Yates `Shuffle` implementation with thread-safe RNG.
 - Application and NuGet package icons.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Chris-Wolfgang/IEnumerable-Extensions/compare/v1.1.0...v1.2.0

--- a/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Shipped.txt
@@ -5,6 +5,6 @@ static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.IsEmpty<T>(this Sys
 static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.IsNullOrEmpty<T>(this System.Collections.Generic.IEnumerable<T>? source) -> bool
 static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.None<T>(this System.Collections.Generic.IEnumerable<T>? source) -> bool
 static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.None<T>(this System.Collections.Generic.IEnumerable<T>? source, System.Func<T, bool>! predicate) -> bool
-static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
-static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!
+static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!
 Wolfgang.Extensions.IEnumerable.IEnumerableExtensions

--- a/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Extensions.IEnumerable/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
 #nullable enable
-*REMOVED*static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
-*REMOVED*static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>! source) -> System.Collections.Generic.IEnumerable<T>!
-static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.Shuffle<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!
-static Wolfgang.Extensions.IEnumerable.IEnumerableExtensions.ToEnumerable<T>(this System.Collections.Generic.IEnumerable<T>? source) -> System.Collections.Generic.IEnumerable<T>!

--- a/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
+++ b/src/Wolfgang.Extensions.IEnumerable/Wolfgang.Extensions.IEnumerable.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
## Summary

Release-prep bundle for v1.4.0. After merge, push the `v1.4.0` tag and `release.yaml` fires (validates tag = csproj version, packs + publishes NuGet, deploys docs).

## Three minimal changes

1. **`<Version>1.3.0</Version>` → `1.4.0`** in the src csproj. `AssemblyVersion` stays pinned at `1.0.0.0` per the binding-stability convention.
2. **PublicAPI promotion**: move the new nullable-parameter signatures for `Shuffle`/`ToEnumerable` from `Unshipped.txt` → `Shipped.txt`; drop the old non-nullable lines from Shipped; truncate Unshipped back to `#nullable enable`.
3. **CHANGELOG**: populate the `[1.4.0]` entry with Added / Changed / Fixed / Security sections covering everything that landed since v1.3.0 (Shuffle opacity + fast paths, nullable alignment, picker security, docfx overlay step, csproj reformat, etc.). Footer compare link updated.

## SemVer

**MINOR** (v1.3.0 → v1.4.0):

- **Behavior change** (observable but strictly additive guarantee): `Shuffle()` result no longer pattern-matches as `List<T>` / `ICollection<T>` / `T[]`. Code that downcast to mutate the internal buffer was relying on an undocumented implementation detail.
- **Annotation-only changes**: nullable parameter alignment on Shuffle/ToEnumerable. Callers with nullable-enabled sources get strictly fewer warnings; nothing breaks.
- **Additive**: new example project, new benchmark suites, Shuffle internal fast paths (perf-only).

Not MAJOR — no breaking public API removals, no behavior change that would surprise a correct caller.

## Test plan

- [x] Local `dotnet build -c Release` — 0 warnings, 0 errors
- [x] Local `dotnet test -c Release -f net10.0` — 59/59 pass
- [ ] CI green
- [ ] After merge: push `v1.4.0` tag; verify release.yaml deploys NuGet + docs