### PR TITLE
bench: restructure ShuffleBenchmarks by source type + ForEach LINQ baseline

### DIFF
--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ForEachBenchmarks.cs
@@ -74,6 +74,21 @@ public class ForEachBenchmarks
         return sum;
     }
 
+    // LINQ has no terminal-ForEach operator, so the closest equivalent is
+    // materializing the source via .ToList() and iterating that. Included as
+    // a "what does eager-materialize-then-iterate cost" reference number.
+    [Benchmark]
+    public long Linq_ToList_Then_Foreach()
+    {
+        long sum = 0;
+        var materialized = _listAsEnumerable.ToList();
+        foreach (var item in materialized)
+        {
+            sum += item;
+        }
+        return sum;
+    }
+
     private static IEnumerable<int> YieldRange(int count)
     {
         for (var i = 0; i < count; i++)

--- a/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ShuffleBenchmarks.cs
+++ b/benchmarks/Wolfgang.Extensions.IEnumerable.Benchmarks/ShuffleBenchmarks.cs
@@ -4,69 +4,123 @@ using BenchmarkDotNet.Engines;
 namespace Wolfgang.Extensions.IEnumerable.Benchmarks;
 
 /// <summary>
-/// Benchmarks comparing different shuffle implementations
+/// Benchmarks for <c>Shuffle&lt;T&gt;()</c> broken down by runtime source type.
+/// v1.4.0's implementation picks one of three fast paths based on a runtime
+/// type check on <c>source</c>, with a fallback for everything else:
+/// <list type="bullet">
+///   <item><b>Fast path — T[]</b>: <see cref="System.Array.Copy(System.Array, System.Array, int)"/> into a new T[] (no enumerator allocation, no <see cref="List{T}"/> wrapper overhead)</item>
+///   <item><b>Fast path — List&lt;T&gt;</b>: <see cref="ICollection{T}.CopyTo"/> (List is itself an ICollection — preallocate T[] of known length, single CopyTo)</item>
+///   <item><b>Fast path — non-list, non-array ICollection&lt;T&gt;</b>: same CopyTo path as List, exercised via a custom wrapper below</item>
+///   <item><b>Fallback — pure IEnumerable&lt;T&gt; (yield iterator)</b>: <see cref="Enumerable.ToArray{T}(IEnumerable{T})"/> (allocates + enumerates)</item>
+/// </list>
+/// The <c>Reference_ToArrayThenShuffle</c> benchmark always runs the
+/// fallback path (regardless of source type), letting the fast-path
+/// benchmarks be read as "how much do we save vs always going through
+/// ToArray + manual Fisher-Yates?".
 /// </summary>
 [MemoryDiagnoser]
 [RankColumn]
 public class ShuffleBenchmarks
 {
     private readonly Consumer _consumer = new();
-    private List<int> _smallList = null!;
-    private List<int> _mediumList = null!;
-    private List<int> _largeList = null!;
+
+    private int[] _array = null!;
+    private List<int> _list = null!;
+    private ICollection<int> _collection = null!;
+    private IEnumerable<int> _yield = null!;
+
+    [Params(100, 1000, 10000)]
+    public int Size { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
-        _smallList = Enumerable.Range(0, 100).ToList();
-        _mediumList = Enumerable.Range(0, 1000).ToList();
-        _largeList = Enumerable.Range(0, 10000).ToList();
+        _array = Enumerable.Range(0, Size).ToArray();
+        _list = Enumerable.Range(0, Size).ToList();
+        // Wrap a List in a custom ICollection that is NOT a List/Array so
+        // the `source is ICollection<T>` branch is exercised distinctly
+        // from the (List-also-is-ICollection) case.
+        _collection = new ReadOnlyCollectionWrapper<int>(Enumerable.Range(0, Size).ToList());
+        _yield = YieldRange(Size);
     }
 
-    // ===== Small List (100 items) =====
+    // ----- Fast path: T[] source (Array.Copy into new T[]) -----
+
+    [Benchmark(Baseline = true)]
+    public void Shuffle_Array() => _array.Shuffle().Consume(_consumer);
+
+    // ----- Fast path: List<T> source (ICollection<T>.CopyTo) -----
 
     [Benchmark]
-    public void CurrentImplementation_Small() => _smallList.Shuffle().Consume(_consumer);
+    public void Shuffle_List() => _list.Shuffle().Consume(_consumer);
+
+    // ----- Fast path: non-list, non-array ICollection<T> source (CopyTo) -----
 
     [Benchmark]
-    public void FisherYates_Small() => ShuffleFisherYates(_smallList).Consume(_consumer);
+    public void Shuffle_ICollectionNotList() => _collection.Shuffle().Consume(_consumer);
 
-    // ===== Medium List (1,000 items) =====
-
-    [Benchmark]
-    public void CurrentImplementation_Medium() => _mediumList.Shuffle().Consume(_consumer);
+    // ----- Fallback: pure IEnumerable<T> source (ToArray()) -----
 
     [Benchmark]
-    public void FisherYates_Medium() => ShuffleFisherYates(_mediumList).Consume(_consumer);
+    public void Shuffle_Yield() => _yield.Shuffle().Consume(_consumer);
 
-    // ===== Large List (10,000 items) =====
+    // ----- Reference: always runs through the IEnumerable<T> fallback path
+    //       (ToArray + manual Fisher-Yates), regardless of the source's
+    //       runtime type. Lets the fast-path rows above be read as
+    //       "how much does the runtime-type fast path save vs always
+    //       going through the fallback?".
 
     [Benchmark]
-    public void CurrentImplementation_Large() => _largeList.Shuffle().Consume(_consumer);
-
-    [Benchmark]
-    public void FisherYates_Large() => ShuffleFisherYates(_largeList).Consume(_consumer);
-
-    /// <summary>
-    /// Fisher-Yates shuffle implementation as suggested in the PR review
-    /// </summary>
-    private static IEnumerable<T> ShuffleFisherYates<T>(IEnumerable<T> source)
+    public void Reference_ToArrayThenShuffle()
     {
-        if (source == null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
-        var list = source.ToList();
-        // Using Random.Shared (requires .NET 6+) - this is why benchmark targets net8.0 only
+        var buffer = _array.ToArray();
         var rng = Random.Shared;
-
-        for (var i = list.Count - 1; i > 0; i--)
+        for (var i = buffer.Length - 1; i > 0; i--)
         {
             var j = rng.Next(i + 1);
-            (list[i], list[j]) = (list[j], list[i]);
+            (buffer[i], buffer[j]) = (buffer[j], buffer[i]);
         }
+        foreach (var item in buffer)
+        {
+            _consumer.Consume(item);
+        }
+    }
 
-        return list;
+    private static IEnumerable<int> YieldRange(int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            yield return i;
+        }
+    }
+
+    /// <summary>
+    /// ICollection&lt;T&gt; wrapper that is deliberately not a List, not an
+    /// array, and not an IList — exercises the ICollection CopyTo branch
+    /// distinctly from the (List-also-is-ICollection) case.
+    /// </summary>
+    private sealed class ReadOnlyCollectionWrapper<T> : ICollection<T>
+    {
+        private readonly List<T> _inner;
+
+        public ReadOnlyCollectionWrapper(List<T> inner) => _inner = inner;
+
+        public int Count => _inner.Count;
+
+        public bool IsReadOnly => true;
+
+        public void Add(T item) => throw new NotSupportedException();
+
+        public void Clear() => throw new NotSupportedException();
+
+        public bool Contains(T item) => _inner.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => _inner.CopyTo(array, arrayIndex);
+
+        public IEnumerator<T> GetEnumerator() => _inner.GetEnumerator();
+
+        public bool Remove(T item) => throw new NotSupportedException();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _inner.GetEnumerator();
     }
 }


### PR DESCRIPTION
## Summary

Reapplies the bench-restructure work from `cr/pr-h-missing-examples@1c00842` that was pushed AFTER PR #171 had already been squash-merged and so never landed on main. The v1.4.0 CHANGELOG advertised both changes; this PR makes them real.

## ShuffleBenchmarks.cs (full rewrite)

The previous file paired `CurrentImplementation_*` against `FisherYates_*` for Small/Medium/Large lists. Post-PR #168 the two branches run the same Fisher-Yates algorithm — comparing a method to itself.

Replaced with `[Params(100, 1000, 10000)]` over five benchmarks that exercise the three internal fast paths v1.4.0's `Shuffle` picks by runtime source type:

| Benchmark | Source | Internal path |
|---|---|---|
| `Shuffle_Array` (baseline) | `T[]` | `Array.Copy` into new T[] |
| `Shuffle_List` | `List<int>` | `ICollection<T>.CopyTo` |
| `Shuffle_ICollectionNotList` | custom `ReadOnlyCollectionWrapper` | `ICollection<T>.CopyTo` |
| `Shuffle_Yield` | yield iterator | `source.ToArray()` fallback |
| `Reference_ToArrayThenShuffle` | `int[]` → ToArray | always the fallback path |

A private `ReadOnlyCollectionWrapper<T>` helper exercises the `ICollection`-but-not-List branch distinctly from the List case (where `is List<T>` happens to also be `is ICollection<T>`).

## ForEachBenchmarks.cs

One added benchmark — `Linq_ToList_Then_Foreach`. LINQ has no terminal-ForEach; the closest LINQ-shaped comparison is materialize-then-iterate. Reference number alongside the existing raw-foreach baseline, BCL `List<T>.ForEach`, and the extension variants on List/array/yield sources.

## No code / API / test changes

Pure benchmark-only additions. Builds clean. `--job dry` validates all 15 Shuffle benchmarks + 6 ForEach benchmarks (no validator rejections).

## SemVer

PATCH-class (benchmarks aren't shipped in the NuGet). No re-tag of v1.4.0 needed; the CHANGELOG mention now matches reality on the next non-bench change that triggers a release.