### PR TITLE
fix(docs): correct docfx template order to render modern-dark UI

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -28,14 +28,16 @@
       {
         "files": [
           "images/**",
-          "public/**"
+          "public/**",
+          "versions.json"
         ]
       }
     ],
     "output": "_site",
     "template": [
+      "default",
       "modern",
-      "default"
+      "modern-dark"
     ],
     "globalMetadata": {
       "_appName": "Wolfgang.Extensions.IEnumerable",


### PR DESCRIPTION
## Symptom

Deployed docs at https://chris-wolfgang.github.io/IEnumerable-Extensions/versions/latest/ render the OLD docfx default template (Bootstrap 3 \`navbar-inverse\`, no theme switcher, no PDF download). Every other canonical Wolfgang.* docs site (DateTime-Extensions reference) uses the new modern-dark UI with Bootstrap 5, theme picker, search with i18n, PDF download.

## Root cause

docfx's \`template\` array is order-sensitive — later entries override earlier ones. The current config is:

\`\`\`json
"template": ["modern", "default"]
\`\`\`

\`default\` overrides \`modern\`, so the docs render the legacy template.

DateTime-Extensions (canonical) uses:

\`\`\`json
"template": ["default", "modern", "modern-dark"]
\`\`\`

— \`modern-dark\` is last, so it's the outermost layer.

## Fix

- Reorder to \`["default", "modern", "modern-dark"]\` matching canonical
- Add \`versions.json\` to the resource files list (matches canonical so the picker fetch resolves to the bundled file)

No code / API / test changes. After merge:

1. \`docfx.yaml\` re-runs on the main push and republishes \`/versions/latest/\` with the modern-dark look.
2. Optionally trigger \`build-all-versions.yaml\` to backfill the same template onto v1.0.0...v1.4.0 docs (the v1.4.0 \`overlay_canonical_docs_assets\` step in docfx.yaml from PR #174 will do this on demand).