### PR TITLE
fix(docs): add purple W logo + register it in docfx.json resources

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -27,6 +27,7 @@
     "resource": [
       {
         "files": [
+          "logo.svg",
           "images/**",
           "public/**",
           "versions.json"

--- a/docfx_project/logo.svg
+++ b/docfx_project/logo.svg
@@ -1,0 +1,23 @@
+<svg width="48" height="48" viewBox="0 0 48 48"
+     xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Soft purple glow for dark backgrounds -->
+    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="2" flood-color="#7c23bb" flood-opacity="0.5"/>
+    </filter>
+  </defs>
+  <style>
+    @font-face {
+      font-family: 'DM Serif Display';
+      src: url('https://fonts.gstatic.com/s/dmserifdisplay/v13/-nF6OG414u0gLgBvIEjRpMqB6mM.woff2') format('woff2');
+    }
+    .fancy {
+      font-family: 'DM Serif Display', serif;
+      font-size: 34px;
+      fill: #7c23bb;
+      letter-spacing: 1px;
+      filter: url(#glow);
+    }
+  </style>
+  <text x="7" y="37" class="fancy">W</text>
+</svg>


### PR DESCRIPTION
## Symptom

IEnumerable-Extensions docs navbar shows the default docfx \"D\" placeholder. Every other Wolfgang.* docs site (DateTime, D20-Dice, etc.) shows the canonical **purple W** (color \`#7c23bb\`, DM Serif Display, soft drop-shadow glow for dark backgrounds).

## Fix

Two-line change:

1. **Add `docfx_project/logo.svg`** — verbatim copy from \`DateTime-Extensions/docfx_project/logo.svg\` (identical to D20-Dice's).
2. **Register `logo.svg` in `docfx_project/docfx.json`** \`resource.files\` so docfx copies it into \`_site/\` alongside \`images/\` / \`public/\` / \`versions.json\`. Matches DateTime canonical exactly.

## After merge

- \`docfx.yaml\` re-fires on the main push → \`/versions/latest/\` shows the W.
- Re-trigger \`build-all-versions.yaml\` to backfill the W onto v1.0.0 → v1.4.0 (each tag's worktree gets main's \`docfx_project\` overlaid).

No code / API / test changes.