### PR TITLE
fix(build-pr): restore -UseBasicParsing on Invoke-WebRequest

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -305,7 +305,7 @@ if (-not $SkipSecurity) {
             $dest = Join-Path $env:LOCALAPPDATA "gitleaks"
             New-Item -ItemType Directory -Force -Path $dest | Out-Null
             $zip = Join-Path $env:TEMP $archive
-            Invoke-WebRequest -Uri $url -OutFile $zip
+            Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
             Expand-Archive -Path $zip -DestinationPath $dest -Force
             Remove-Item $zip -ErrorAction SilentlyContinue
             $env:PATH = "$dest;$env:PATH"


### PR DESCRIPTION
## Summary

Adds `-UseBasicParsing` to the `Invoke-WebRequest` call in the gitleaks auto-installer of `scripts/build-pr.ps1`.

On **Windows PowerShell 5.1**, `Invoke-WebRequest` without `-UseBasicParsing` uses the legacy IE-based parser and throws *"the Internet Explorer engine is not available..."* on stock / minimal Windows. The Windows branch is reachable from PS 5.1 (entered via the `$env:OS -match 'Windows'` half of the guard). PowerShell 7+ accepts the switch as a no-op, so this works on both hosts at zero cost.

Canonical fix from Chris-Wolfgang/repo-template#418, fanned out to the fleet. `build-pr.ps1` is not a protected file, so this merges through the normal ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)