### PR TITLE
docs(readme): fix PR build badge query so it renders live status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of extension methods for `IEnumerable<T>` in .NET.
 
 [![NuGet](https://img.shields.io/nuget/v/Wolfgang.Extensions.IEnumerable.svg?logo=nuget&label=NuGet)](https://www.nuget.org/packages/Wolfgang.Extensions.IEnumerable)
 [![NuGet downloads](https://img.shields.io/nuget/dt/Wolfgang.Extensions.IEnumerable.svg?logo=nuget&label=downloads)](https://www.nuget.org/packages/Wolfgang.Extensions.IEnumerable)
-[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/IEnumerable-Extensions/pr.yaml?branch=main&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/IEnumerable-Extensions/actions/workflows/pr.yaml)
+[![PR build](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/IEnumerable-Extensions/pr.yaml?event=pull_request_target&label=PR%20build&logo=github)](https://github.com/Chris-Wolfgang/IEnumerable-Extensions/actions/workflows/pr.yaml)
 [![Release](https://img.shields.io/github/actions/workflow/status/Chris-Wolfgang/IEnumerable-Extensions/release.yaml?label=release&logo=github)](https://github.com/Chris-Wolfgang/IEnumerable-Extensions/actions/workflows/release.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)


### PR DESCRIPTION
## Summary

Same fix as [Try-Pattern](https://github.com/Chris-Wolfgang/Try-Pattern) — `pr.yaml` runs on `pull_request_target`, so `?branch=main` on the shields.io URL finds nothing and the badge currently renders "no status". `?event=pull_request_target` is what actually matches.

One-character line diff in the shields URL query string. Docs-only.